### PR TITLE
Remove unnecessary assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Dataform package containing commonly used SQL functions and table definitions, f
 3. Ensure that it is synchronised with its own dedicated Github repository.
 4. Add the following line within the dependencies block of the package.json file in your Dataform project:
 ```
-"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.6.4"
+"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.6.5"
 ```
 It should now look something like:
 ```
 {
     "dependencies": {
         "@dataform/core": "1.22.0",
-        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.6.4"
+        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.6.5"
     }
 }
 ```

--- a/includes/flattened_entity_latest.js
+++ b/includes/flattened_entity_latest.js
@@ -10,7 +10,7 @@ module.exports = (params) => {
     type: "table",
     assertions: {
       uniqueKey: ["id"],
-      nonNull: ["last_streamed_event_occurred_at", "last_streamed_event_type", "id", "created_at", "updated_at"]
+      nonNull: ["last_streamed_event_occurred_at", "last_streamed_event_type", "id"]
     },
     bigquery: {
       partitionBy: "DATE(created_at)",

--- a/includes/flattened_entity_version.js
+++ b/includes/flattened_entity_version.js
@@ -11,7 +11,7 @@ module.exports = (params) => {
     dependencies: [params.eventSourceName + "_entities_are_missing_expected_fields"],
     assertions: {
       uniqueKey: ["valid_from", "id"],
-      nonNull: ["id", "created_at", "updated_at"],
+      nonNull: ["id"],
       rowConditions: [
         'valid_from < valid_to OR valid_to IS NULL'
       ]


### PR DESCRIPTION
Remove assertions that check for non-null created_at and updated_at date for entity versions - these aren't necessary and can cause failures when these are missing in legacy data