### PR TITLE
Couple of funnel analysis fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Dataform package containing commonly used SQL functions and table definitions, f
 3. Ensure that it is synchronised with its own dedicated Github repository.
 4. Add the following line within the dependencies block of the package.json file in your Dataform project:
 ```
-"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.9.2"
+"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.9.3"
 ```
 It should now look something like:
 ```
 {
     "dependencies": {
         "@dataform/core": "1.22.0",
-        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.9.2"
+        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v0.9.3"
     }
 }
 ```

--- a/includes/pageview_with_funnels.js
+++ b/includes/pageview_with_funnels.js
@@ -112,6 +112,7 @@ WITH
     FIRST_VALUE(request_query) OVER previous_request AS previous_request_query
   FROM
     web_request QUALIFY request_path != previous_request_path
+    OR (previous_request_path IS NULL AND request_path IS NOT NULL)
     OR NOT request_queries_are_equal(request_query, previous_request_query)
   WINDOW
     previous_request AS (
@@ -122,7 +123,7 @@ WITH
   web_request_with_processed_referer AS (
   SELECT
     * EXCEPT(previous_request_path, previous_request_query),
-    REGEXP_EXTRACT(request_referer, r"[^\\/](\\/[^\\/][^?]*)(?:\\?|$)") AS request_referer_path,
+    REGEXP_EXTRACT(request_referer, r"[^:\\/](\\/[^\\?]*)(?:\\?|$)") AS request_referer_path,
     ARRAY(
     SELECT
       AS STRUCT REGEXP_EXTRACT(string, r"^([^=]+)=") AS key,


### PR DESCRIPTION
- Stop the first pageview of the day being removed from the funnel as a duplicate pageview (because its previous_request_path was NULL which failed a != condition)
- Extract paths correctly from referers for URLs that end /?param=value or just /