### PR TITLE
Stop excluding bot traffic from funnel analysis and session tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Dataform package containing commonly used SQL functions and table definitions, f
 3. Ensure that it is synchronised with its own dedicated Github repository.
 4. Add the following line within the dependencies block of the package.json file in your Dataform project:
 ```
-"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.2"
+"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.3"
 ```
 It should now look something like:
 ```
 {
     "dependencies": {
         "@dataform/core": "1.22.0",
-        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.2"
+        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.0.3"
     }
 }
 ```

--- a/includes/pageview_with_funnels.js
+++ b/includes/pageview_with_funnels.js
@@ -113,7 +113,7 @@ module.exports = (params) => {
   }).query(ctx => `
 WITH
   web_request AS (
-  /* Filter out non-web request events, non-HTML pages and bot events, remove URI formatted characters from the referer and flatten repeated parameter values in the query string into separate parameters */
+  /* Filter out non-web request events & non-HTML pages, remove URI formatted characters from the referer and flatten repeated parameter values in the query string into separate parameters */
   SELECT
     * EXCEPT(request_query,
       request_referer,
@@ -131,7 +131,6 @@ WITH
     ${ctx.ref("events_" + params.eventSourceName)}
   WHERE
     event_type="web_request"
-    AND device_category != "bot"
     AND CONTAINS_SUBSTR(response_content_type,
       "text/html")
     AND DATE(occurred_at) < CURRENT_DATE


### PR DESCRIPTION
Instead we'll need to filter them out at dashboard data source level (including in the template).

Currently when we use these tables for attribution modelling, if the bot filtering is slightly inaccurate, we can't attribute a user arriving at a service to any session (because the first click was from a user we deemed to be a bot!). This prevents this.

Upgrade instructions need to ask users to full refresh their pageview_with_funnels tables.