### PR TITLE
Fix pastKeyNames bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Dataform package containing commonly used SQL functions and table definitions, f
 3. Ensure that it is synchronised with its own dedicated Github repository.
 4. Add the following line within the dependencies block of the package.json file in your Dataform project:
 ```
-"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.3.0"
+"dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.3.1"
 ```
 It should now look something like:
 ```
 {
     "dependencies": {
         "@dataform/core": "2.4.2",
-        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.3.0"
+        "dfe-analytics-dataform": "git+https://github.com/DFE-Digital/dfe-analytics-dataform.git#v1.3.1"
     }
 }
 ```

--- a/includes/flattened_entity_version.js
+++ b/includes/flattened_entity_version.js
@@ -119,9 +119,15 @@ FROM (
     SELECT
       AS STRUCT
       ${tableSchema.keys.map(key => {
-          return `ANY_VALUE(IF(key="${key.keyName}",value,NULL)) AS ${key.alias || key.keyName},`;
+          var pastKeyNamesSql = '';
+          if (key.pastKeyNames) {
+          key.pastKeyNames.forEach(pastKeyName => {
+            pastKeyNamesSql += `      ANY_VALUE(IF(key="${pastKeyName}",value,NULL)) AS ${pastKeyName},\n`;
+            });
+          }
+          return `ANY_VALUE(IF(key="${key.keyName}",value,NULL)) AS ${key.alias || key.keyName},\n` + pastKeyNamesSql;
       }
-    ).join('\n')
+    ).join('')
   }
     FROM (
       SELECT


### PR DESCRIPTION
This caused errors when pastKeyNames was used when not in combination with the alias parameter.

Essentially the SQL in this query works by turning the DATA array of STRUCTs (1) into a simple STRUCT, and then (2) into a table. (2) included the pastKeyNames as intended, but (1) didn't. So (2) generated an error to say that it couldn't find a field called one of the past key names in the data_STRUCT field. This fix corrects (1) by adding in the necessary field(s) there so this doesn't happen any more.