### PR TITLE
referential_integrity_check improvements

### DIFF
--- a/includes/referential_integrity_check.js
+++ b/includes/referential_integrity_check.js
@@ -13,14 +13,14 @@ module.exports = (params) => {
         }
       )
     .query(ctx =>
-      "SELECT * FROM"
+      "SELECT * FROM\n"
       // Generate a separate subquery for each foreign key in the table that a referential integrity check is configured for
       + tableSchema.keys
       // Only generate these subqueries for keys in the table that have the foreignKeyTable parameter set
         .filter(key => key.foreignKeyTable)
         .map(
           key =>
-            "(SELECT '"
+            "  (SELECT '"
             // Generate a human readable error message as the first column if the assertion fails
             + (key.alias || key.keyName)
             + " does not match any "
@@ -50,5 +50,8 @@ module.exports = (params) => {
         )
         // UNION ALL the collection of subqueries together - this will mean that if a single instance of an entity has referential integrity failures on more than one foreign key, one row will be generated per foreign key it has a failure for
         .join('\nUNION ALL\n')
+        + "\nORDER BY\n  issue_description ASC,\n  "
+        + tableSchema.entityTableName
+        + "_updated_at DESC"
   ))
 }

--- a/includes/referential_integrity_check.js
+++ b/includes/referential_integrity_check.js
@@ -30,9 +30,15 @@ module.exports = (params) => {
             + key.foreignKeyTable
             + "_latest_"
             + params.eventSourceName
-            + "' AS issue_description, id, "
+            + "' AS issue_description, id AS "
+            + tableSchema.entityTableName
+            + "_id, created_at AS "
+            + tableSchema.entityTableName
+            + "_created_at, updated_at AS "
+            + tableSchema.entityTableName
+            + "_updated_at, "
             + (key.alias || key.keyName)
-            + " AS id_not_matched_to_foreign_key FROM "
+            + " AS missing_id_in_related_table FROM "
             + ctx.ref(tableSchema.entityTableName + "_latest_" + params.eventSourceName)
             + " WHERE "
             + (key.alias || key.keyName)


### PR DESCRIPTION
- Add created_at, updated_at to referential_integrity_check
- Add aliases/rename aliases to clarify that they're the fields in the table we *have* data for, not the one that's missing the data
- Order referential_integrity_check more helpfully