### PR TITLE
Support new checksum ID sort orders introduced in dfe-analytics v1.11.5

### DIFF
--- a/includes/entity_ids_do_not_match.js
+++ b/includes/entity_ids_do_not_match.js
@@ -12,7 +12,8 @@ module.exports = (params) => {
             entity_table_name,
             ${data_functions.eventDataExtract("data", "row_count", false, "integer")} AS row_count,
             ${data_functions.eventDataExtract("data", "checksum", false, "string")} AS checksum,
-            ${data_functions.eventDataExtract("data", "checksum_calculated_at", false, "timestamp")} AS checksum_calculated_at
+            ${data_functions.eventDataExtract("data", "checksum_calculated_at", false, "timestamp")} AS checksum_calculated_at,
+            LOWER(${data_functions.eventDataExtract("data", "order_column", false, "string")}) AS order_column
           FROM
             ${ctx.ref("events_" + params.eventSourceName)}
           WHERE
@@ -22,18 +23,19 @@ module.exports = (params) => {
             /* Only process the most recent check for each entity_table_name */
             QUALIFY ROW_NUMBER() OVER (PARTITION BY entity_table_name ORDER BY occurred_at DESC) = 1
           ),
-          tables_with_metrics AS (
+          /* BigQuery has a 100MB limit for the data processed across all aggregate functions within an individual subquery. */
+          /* Calculating checksums with three different sort orders depending on order_column causes this limit to be breached if completed within the same subquery. */
+          /* To work around this each order is calculated in a separate subquery below and then recombined. */
+          tables_with_updated_at_metrics AS (
           SELECT
             check.entity_table_name,
             check.row_count AS database_row_count,
             COUNT(DISTINCT entity_version.updated_at) AS bigquery_row_count,
             check.checksum AS database_checksum,
-            TO_HEX(MD5(
-              IF(
-                COUNT(entity_version.entity_id) > 0,
-                STRING_AGG(entity_version.entity_id, "" ORDER BY entity_version.updated_at ASC),
-                ""
-                ))) AS bigquery_checksum,
+            check.order_column,
+            TO_HEX(MD5( STRING_AGG(entity_version.entity_id, ""
+                ORDER BY
+                  entity_version.updated_at ASC))) AS bigquery_checksum,
             check.checksum_calculated_at
           FROM
             check
@@ -45,12 +47,105 @@ module.exports = (params) => {
             AND ((entity_version.valid_to IS NULL
                 OR entity_version.valid_to > check.checksum_calculated_at)
               AND entity_version.valid_from <= check.checksum_calculated_at)
+          WHERE
+            check.order_column = "updated_at"
+            /* Default to sorting by updated_at for backwards compatibility */
+            OR check.order_column IS NULL
           GROUP BY
             check.entity_table_name,
             check.row_count,
             check.checksum,
+            check.checksum_calculated_at,
+            check.order_column ),
+          tables_with_created_at_metrics AS (
+          SELECT
+            check.entity_table_name,
+            check.row_count AS database_row_count,
+            COUNT(DISTINCT entity_version.updated_at) AS bigquery_row_count,
+            check.checksum AS database_checksum,
+            check.order_column,
+            TO_HEX(MD5( STRING_AGG(entity_version.entity_id, ""
+                ORDER BY
+                  entity_version.created_at ASC))) AS bigquery_checksum,
             check.checksum_calculated_at
-          )
+          FROM
+            check
+          LEFT JOIN
+            ${ctx.ref(params.eventSourceName + "_entity_version")} AS entity_version
+          ON
+            check.entity_table_name = entity_version.entity_table_name
+            /* Join on to entity versions which were valid at the time the checksum was calculated from the database */
+            AND ((entity_version.valid_to IS NULL
+                OR entity_version.valid_to > check.checksum_calculated_at)
+              AND entity_version.valid_from <= check.checksum_calculated_at)
+          WHERE
+            check.order_column = "created_at"
+          GROUP BY
+            check.entity_table_name,
+            check.row_count,
+            check.checksum,
+            check.checksum_calculated_at,
+            check.order_column ),
+          tables_with_entity_id_metrics AS (
+          SELECT
+            check.entity_table_name,
+            check.row_count AS database_row_count,
+            COUNT(DISTINCT entity_version.updated_at) AS bigquery_row_count,
+            check.checksum AS database_checksum,
+            check.order_column,
+            TO_HEX(MD5( STRING_AGG(entity_version.entity_id, ""
+                ORDER BY
+                  entity_version.entity_id ASC))) AS bigquery_checksum,
+            check.checksum_calculated_at
+          FROM
+            check
+          LEFT JOIN
+            ${ctx.ref(params.eventSourceName + "_entity_version")} AS entity_version
+          ON
+            check.entity_table_name = entity_version.entity_table_name
+            /* Join on to entity versions which were valid at the time the checksum was calculated from the database */
+            AND ((entity_version.valid_to IS NULL
+                OR entity_version.valid_to > check.checksum_calculated_at)
+              AND entity_version.valid_from <= check.checksum_calculated_at)
+          WHERE
+            check.order_column = "id"
+          GROUP BY
+            check.entity_table_name,
+            check.row_count,
+            check.checksum,
+            check.checksum_calculated_at,
+            check.order_column ),
+          tables_with_metrics AS (
+          SELECT
+            check.entity_table_name,
+            check.row_count AS database_row_count,
+            COALESCE(tables_with_updated_at_metrics.bigquery_row_count, tables_with_created_at_metrics.bigquery_row_count, tables_with_entity_id_metrics.bigquery_row_count) AS bigquery_row_count,
+            check.checksum AS database_checksum,
+            check.order_column,
+            check.checksum_calculated_at,
+            CASE
+              WHEN NOT COALESCE(tables_with_updated_at_metrics.bigquery_row_count, tables_with_created_at_metrics.bigquery_row_count, tables_with_entity_id_metrics.bigquery_row_count) > 0 THEN TO_HEX(MD5(""))
+              WHEN check.order_column = "created_at" THEN tables_with_created_at_metrics.bigquery_checksum
+              WHEN check.order_column = "id" THEN tables_with_entity_id_metrics.bigquery_checksum
+            ELSE
+            /* Default to sorting by updated_at for backwards compatibility */
+            tables_with_updated_at_metrics.bigquery_checksum
+          END
+            AS bigquery_checksum
+          FROM
+            check
+          LEFT JOIN
+            tables_with_updated_at_metrics
+          USING
+            (entity_table_name)
+          LEFT JOIN
+            tables_with_created_at_metrics
+          USING
+            (entity_table_name)
+          LEFT JOIN
+            tables_with_entity_id_metrics
+          USING
+            (entity_table_name))
         SELECT
           *,
           CASE
@@ -65,8 +160,7 @@ module.exports = (params) => {
         FROM
           tables_with_metrics
         WHERE
-          /* Only fail if something doesn't match */
-          database_checksum != bigquery_checksum
+          /* Only fail if something doesn't match */ database_checksum != bigquery_checksum
           OR database_row_count != bigquery_row_count
         ORDER BY
           entity_table_name ASC`

--- a/includes/entity_ids_do_not_match.js
+++ b/includes/entity_ids_do_not_match.js
@@ -160,7 +160,8 @@ module.exports = (params) => {
         FROM
           tables_with_metrics
         WHERE
-          /* Only fail if something doesn't match */ database_checksum != bigquery_checksum
+          /* Only fail if something doesn't match */
+          database_checksum != bigquery_checksum
           OR database_row_count != bigquery_row_count
         ORDER BY
           entity_table_name ASC`

--- a/includes/entity_ids_do_not_match.js
+++ b/includes/entity_ids_do_not_match.js
@@ -5,7 +5,7 @@ module.exports = (params) => {
           SELECT
             check.entity_table_name,
             check.row_count AS database_row_count,
-            COUNT(DISTINCT entity_version.${sortField}) AS bigquery_row_count,
+            COUNT(DISTINCT entity_version.entity_id) AS bigquery_row_count,
             check.checksum AS database_checksum,
             check.order_column,
             TO_HEX(MD5( STRING_AGG(entity_version.entity_id, ""


### PR DESCRIPTION
Note this required a substantial rework because BigQuery has a 100MB limit for the data processed across all aggregate functions within an individual subquery. Calculating checksums with three different sort orders depending on order_column causes this limit to be breached if completed within the same subquery. To work around this each order is calculated in a separate subquery and then recombined.