### PR TITLE
Add waits between constraint operations to avoid hitting the 5 table updates in 10s BQ limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Dataform package containing commonly used SQL functions and table definitions, f
 4. Set up a production release configuration - see [Google documentation](https://cloud.google.com/dataform/docs/release-configurations).
 5. Add the following line within the dependencies block of the package.json file in your Dataform project:
 ```
-"dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.0.tar.gz"
+"dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz"
 ```
 It should now look something like:
 ```
 {
     "dependencies": {
         "@dataform/core": "2.8.4",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.0.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It should now look something like:
 ```
 {
     "dependencies": {
-        "@dataform/core": "2.8.4",
+        "@dataform/core": "2.9.0",
         "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.9.1.tar.gz"
     }
 }

--- a/includes/data_functions.js
+++ b/includes/data_functions.js
@@ -100,7 +100,7 @@ function eventDataExtract(dataField, keyToExtract, dynamic = false, dataType = '
     if (dataType == "string") {
         thisValueWithDataTypeAppliedSql = 'this_value';
     } else if (dataType == "boolean") {
-        thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS BOOL)`;
+        thisValueWithDataTypeAppliedSql = `SAFE_CAST(LOWER(this_value) AS BOOL)`;
     } else if (dataType == "timestamp") {
         thisValueWithDataTypeAppliedSql = stringToTimestamp('this_value');
     } else if (dataType == "date") {

--- a/includes/data_functions.js
+++ b/includes/data_functions.js
@@ -244,14 +244,14 @@ function wait(intervalString) {
 keyInForeignTable defaults to "id" if not specified. Composite keys may be specified for keyInThisTable and keyInForeignTable as a comma separated list.
 e.g. 
 post_operations {
-    data_functions.setKeyConstraints(ctx, dataform, {
+    ${data_functions.setKeyConstraints(ctx, dataform, {
     primaryKey: "myidname",
     foreignKeys: [
         {keyInThisTable: "myotherkeyname", foreignTable: "myothertable", keyInForeignTable: "myotheridname"},
         {keyInThisTable: "anotherkeyname", foreignTable: "myotherothertable"},
         {keyInThisTable: "firstpartofcompositekey, secondpartofcompositekey", foreignTable: "myothertable", keyInForeignTable: "firstpartofcompositekeyinothertable, secondpartofcompositekeyinothertable"}
         ]
-    })
+    })}
 }
 Using this function enables project level table definitions to avoid having to handle their own workarounds for the following issues:
 1. Without putting the ALTER TABLE statements in a conditional IF TRUE THEN... END IF; block, although the script would execute without error, BigQuery query compilation unhelpfully returns an error on the line that attempts to add a primary key if a primary key already exists, ignoring the fact that a previous step in the script removes the primary key.

--- a/includes/data_functions.js
+++ b/includes/data_functions.js
@@ -1,7 +1,7 @@
 /* Parses a string as a timestamp, attempting multiple formats. If timezone is not present, assumes timezone is Europe/London. If unable to parse the string as a timestamp in any of the formats, returns NULL (not an error). */
 
 function stringToTimestamp(string) {
-  return `COALESCE(
+    return `COALESCE(
     SAFE.PARSE_TIMESTAMP(
       '%FT%H:%M:%E*S%Ez',
       TRIM(
@@ -46,7 +46,7 @@ function stringToTimestamp(string) {
 /* Parses a string as a date, attempting multiple formats (including a timestamp cast to a date). If unable to parse the string as a date in any of the formats, returns NULL (not an error). */
 
 function stringToDate(string) {
-  return `COALESCE(
+    return `COALESCE(
     SAFE.PARSE_DATE(
       '%F',
       ${string}
@@ -62,7 +62,7 @@ function stringToDate(string) {
 /* Shortcut to extract a string like [3,75,2,1] from a DATA struct using eventDataExtract and then convert it into an ARRAY of integers. */
 
 function stringToIntegerArray(string) {
-  return `ARRAY(
+    return `ARRAY(
     SELECT
       step_int
     FROM
@@ -88,57 +88,48 @@ function stringToIntegerArray(string) {
 /* The events table uses a repeated STRUCT field containing field names key and value to store data about the event as a NoSQL-style set (document) of key-value pairs. Value is in turn a repeated field within the STRUCT. This function extracts the value of a given key from said repeated STRUCTS. If more than one value is present for key or in the unlikely event that the same key occurs multiple times, returns a comma-separated list of all values for this key. If the only values are empty strings or not present, returns NULL */
 
 function eventDataExtract(dataField, keyToExtract, dynamic = false, dataType = 'string', isArray = false) {
-  var condition = `key = "${keyToExtract}"`;
-  if (dynamic) {
-    condition = `key = ${keyToExtract}`;
-    if (keyToExtract === 'key') {
-      throw new Error("eventDataExtract cannot be used in dynamic mode to extract the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to eventDataExtract.");
-    }
-  };
-
-  var thisValueWithDataTypeAppliedSql = `this_value`;
-  if (dataType == "string") {
-    thisValueWithDataTypeAppliedSql = 'this_value';
-  }
-  else if (dataType == "boolean") {
-    thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS BOOL)`;
-  }
-  else if (dataType == "timestamp") {
-    thisValueWithDataTypeAppliedSql = stringToTimestamp('this_value');
-  }
-  else if (dataType == "date") {
-    thisValueWithDataTypeAppliedSql = stringToDate('this_value');
-  }
-  else if (dataType == "integer") {
-    thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS INT64)`;
-  }
-  else if (dataType == "integer_array") {
-    if (isArray) {
-      throw new Error("isArray: true cannot be set for dataType: integer_array. You might just need dataType: integer instead.");
+    var condition = `key = "${keyToExtract}"`;
+    if (dynamic) {
+        condition = `key = ${keyToExtract}`;
+        if (keyToExtract === 'key') {
+            throw new Error("eventDataExtract cannot be used in dynamic mode to extract the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to eventDataExtract.");
+        }
     };
-    thisValueWithDataTypeAppliedSql = stringToIntegerArray('this_value');
-  }
-  else if (dataType == "float") {
-    thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS FLOAT64)`;
-  }
-  else if (dataType == "json") {
-    thisValueWithDataTypeAppliedSql = `SAFE.PARSE_JSON(this_value)`;
-  }
-  else {
-    throw new Error(`Unrecognised dataType '${dataType}' for field '${keyToExtract}'. dataType should be set to boolean, timestamp, date, integer, integer_array, float, json or string or not set.`);
-  };
 
-  var arraysOfValuesToOutputDataSql = `NULLIF(STRING_AGG(${thisValueWithDataTypeAppliedSql}, ","), "")`;
-  var nullSql = `NULL`;
-  if (isArray) {
-    arraysOfValuesToOutputDataSql = `ARRAY_AGG(${thisValueWithDataTypeAppliedSql})`;
-    nullSql = `[]`;
-  }
-  else if (dataType != "string") {
-    arraysOfValuesToOutputDataSql = `IF(COUNT(this_value) > 1, NULL, ANY_VALUE(${thisValueWithDataTypeAppliedSql}))`;
-  };
+    var thisValueWithDataTypeAppliedSql = `this_value`;
+    if (dataType == "string") {
+        thisValueWithDataTypeAppliedSql = 'this_value';
+    } else if (dataType == "boolean") {
+        thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS BOOL)`;
+    } else if (dataType == "timestamp") {
+        thisValueWithDataTypeAppliedSql = stringToTimestamp('this_value');
+    } else if (dataType == "date") {
+        thisValueWithDataTypeAppliedSql = stringToDate('this_value');
+    } else if (dataType == "integer") {
+        thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS INT64)`;
+    } else if (dataType == "integer_array") {
+        if (isArray) {
+            throw new Error("isArray: true cannot be set for dataType: integer_array. You might just need dataType: integer instead.");
+        };
+        thisValueWithDataTypeAppliedSql = stringToIntegerArray('this_value');
+    } else if (dataType == "float") {
+        thisValueWithDataTypeAppliedSql = `SAFE_CAST(this_value AS FLOAT64)`;
+    } else if (dataType == "json") {
+        thisValueWithDataTypeAppliedSql = `SAFE.PARSE_JSON(this_value)`;
+    } else {
+        throw new Error(`Unrecognised dataType '${dataType}' for field '${keyToExtract}'. dataType should be set to boolean, timestamp, date, integer, integer_array, float, json or string or not set.`);
+    };
 
-  return `
+    var arraysOfValuesToOutputDataSql = `NULLIF(STRING_AGG(${thisValueWithDataTypeAppliedSql}, ","), "")`;
+    var nullSql = `NULL`;
+    if (isArray) {
+        arraysOfValuesToOutputDataSql = `ARRAY_AGG(${thisValueWithDataTypeAppliedSql})`;
+        nullSql = `[]`;
+    } else if (dataType != "string") {
+        arraysOfValuesToOutputDataSql = `IF(COUNT(this_value) > 1, NULL, ANY_VALUE(${thisValueWithDataTypeAppliedSql}))`;
+    };
+
+    return `
     (
       SELECT
         IF(COUNT(this_value) = 0, ${nullSql}, ${arraysOfValuesToOutputDataSql}) AS concat_value
@@ -150,28 +141,28 @@ function eventDataExtract(dataField, keyToExtract, dynamic = false, dataType = '
 };
 
 function eventDataExtractTimestamp(dataField, keyToExtract, dynamic = false) {
-  return eventDataExtract(dataField, keyToExtract, dynamic, "timestamp")
+    return eventDataExtract(dataField, keyToExtract, dynamic, "timestamp")
 };
 
 function eventDataExtractDate(dataField, keyToExtract, dynamic = false) {
-  return eventDataExtract(dataField, keyToExtract, dynamic, "date")
+    return eventDataExtract(dataField, keyToExtract, dynamic, "date")
 };
 
 function eventDataExtractIntegerArray(dataField, keyToExtract, dynamic = false) {
-  return eventDataExtract(dataField, keyToExtract, dynamic, "integer_array")
+    return eventDataExtract(dataField, keyToExtract, dynamic, "integer_array")
 };
 
 /* The events table uses a repeated STRUCT field containing field names key and value to store data about the event as a NoSQL-style set (document) of key-value pairs. Value is in turn a repeated field within the STRUCT. This function extracts the value of all keys beginning key_to_extract_begins from said repeated STRUCTS and returns them as a comma-separated list of all values for this key. If the only values are empty strings or no keys begin key_to_extract_begins, returns NULL. */
 
 function eventDataExtractListOfStringsBeginning(dataField, keyToExtractBegins, dynamic = false) {
-  var condition = `STARTS_WITH(key, "${keyToExtractBegins}")`;
-  if (dynamic) {
-    condition = `STARTS_WITH(key, ${keyToExtractBegins})`;
-    if (keyToExtractBegins === 'key') {
-      throw new Error("eventDataExtractListOfStringsBeginning cannot be used in dynamic mode to extract the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to eventDataExtractListOfStringsBeginning.");
-    }
-  };
-  return `NULLIF(
+    var condition = `STARTS_WITH(key, "${keyToExtractBegins}")`;
+    if (dynamic) {
+        condition = `STARTS_WITH(key, ${keyToExtractBegins})`;
+        if (keyToExtractBegins === 'key') {
+            throw new Error("eventDataExtractListOfStringsBeginning cannot be used in dynamic mode to extract the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to eventDataExtractListOfStringsBeginning.");
+        }
+    };
+    return `NULLIF(
     (
       SELECT
         IF(ARRAY_LENGTH(ARRAY_CONCAT_AGG(value)) = 0, NULL, ARRAY_TO_STRING(ARRAY_CONCAT_AGG(value), ",")) as concat_value
@@ -187,14 +178,14 @@ function eventDataExtractListOfStringsBeginning(dataField, keyToExtractBegins, d
 /* The events table uses a repeated STRUCT field containing field names key and value to store data about the event as a NoSQL-style set (document) of key-value pairs. Returns TRUE if a given key is present in DATA, and FALSE otherwise. */
 
 function keyIsInEventData(dataField, keyToLookFor, dynamic = false) {
-  var condition = `key = "${keyToLookFor}"`;
-  if (dynamic) {
-    condition = `key = ${keyToLookFor}`;
-    if (keyToLookFor === 'key') {
-      throw new Error("keyIsInEventData cannot be used in dynamic mode to search for the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to keyIsInEventData.");
-    }
-  };
-  return `(
+    var condition = `key = "${keyToLookFor}"`;
+    if (dynamic) {
+        condition = `key = ${keyToLookFor}`;
+        if (keyToLookFor === 'key') {
+            throw new Error("keyIsInEventData cannot be used in dynamic mode to search for the value from DATA with a key in DATA that matches a field/variable named key. Try giving your key field/variable an alias first before passing it to keyIsInEventData.");
+        }
+    };
+    return `(
     SELECT
       COUNT(*)
     FROM
@@ -212,7 +203,7 @@ function keyIsInEventData(dataField, keyToLookFor, dynamic = false) {
 /* Sets the value of key to value within a DATA struct in a streamed event. */
 
 function eventDataCreateOrReplace(dataField, keyToSet, valueToSet) {
-  return `ARRAY_CONCAT(
+    return `ARRAY_CONCAT(
     ARRAY(
       (
         SELECT
@@ -232,9 +223,26 @@ function eventDataCreateOrReplace(dataField, keyToSet, valueToSet) {
 )`
 };
 
+/* Wait for a specified interval in the context of GoogleSQL procedural language (i.e. a SQL script, not an individual query) */
+function wait(intervalString) {
+    return `
+    BEGIN
+    DECLARE WAIT STRING;
+    DECLARE DELAY_TIME DATETIME;
+    SET WAIT = 'TRUE';
+    SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL ${intervalString});
+    WHILE WAIT = 'TRUE' DO
+      IF (DELAY_TIME < CURRENT_DATETIME) THEN
+         SET WAIT = 'FALSE';
+      END IF;
+    END WHILE;
+    END;
+    `;
+}
+
 /* Delete all key constraints on the table - even ones that are no longer included in dfeAnalyticsDataform() configuration */
 function dropAllKeyConstraints(ctx, dataform) {
-  return `
+    return `
   ALTER TABLE ${ctx.self()} DROP PRIMARY KEY IF EXISTS;
   FOR constraint_to_drop IN (
     SELECT
@@ -247,19 +255,21 @@ function dropAllKeyConstraints(ctx, dataform) {
     )
   DO
     ALTER TABLE ${ctx.self()} DROP CONSTRAINT IF EXISTS constraint_to_delete;
+    ${wait("2 SECOND")}
   END FOR;`
 };
 
 module.exports = {
-  stringToTimestamp,
-  stringToDate,
-  stringToIntegerArray,
-  eventDataExtract,
-  eventDataExtractTimestamp,
-  eventDataExtractDate,
-  eventDataExtractIntegerArray,
-  eventDataExtractListOfStringsBeginning,
-  keyIsInEventData,
-  eventDataCreateOrReplace,
-  dropAllKeyConstraints
+    stringToTimestamp,
+    stringToDate,
+    stringToIntegerArray,
+    eventDataExtract,
+    eventDataExtractTimestamp,
+    eventDataExtractDate,
+    eventDataExtractIntegerArray,
+    eventDataExtractListOfStringsBeginning,
+    keyIsInEventData,
+    eventDataCreateOrReplace,
+    wait,
+    dropAllKeyConstraints
 };

--- a/includes/data_functions.js
+++ b/includes/data_functions.js
@@ -285,7 +285,7 @@ function setKeyConstraints(ctx, dataform, constraints) {
           AND table_name = "${ctx.name()}"
         )
       DO
-        ALTER TABLE ${ctx.self()} DROP CONSTRAINT IF EXISTS constraint_to_delete;
+        ALTER TABLE ${ctx.self()} DROP CONSTRAINT IF EXISTS constraint_to_drop;
         ${wait("2 SECOND")}
       END FOR;
     /* Set primary key */

--- a/includes/entity_version.js
+++ b/includes/entity_version.js
@@ -164,10 +164,8 @@ WHERE
   )`).preOps(ctx => `DECLARE event_timestamp_checkpoint DEFAULT (
         ${ctx.when(ctx.incremental(), `SELECT MAX(valid_to) FROM ${ctx.self()}`, `SELECT TIMESTAMP("2018-01-01")`)}
       )`)
-        .postOps(ctx => `
-  IF TRUE THEN /* Workaround - without putting the ALTER TABLE statements in a conditional block, although the script would execute without error, BigQuery query compilation unhelpfully returns an error on the line that attempts to add a primary key if a primary key already exists, ignoring the fact that a previous step in the script removes the primary key. */
-  ${data_functions.dropAllKeyConstraints(ctx, dataform)}
-  ALTER TABLE ${ctx.self()} ADD PRIMARY KEY(entity_id, valid_from, entity_table_name) NOT ENFORCED;
-  END IF;
+    .postOps(ctx => `${data_functions.setKeyConstraints(ctx, dataform, {
+            primaryKey: "entity_id, valid_from, entity_table_name"
+            })}
     `)
 }

--- a/includes/flattened_entity_latest.js
+++ b/includes/flattened_entity_latest.js
@@ -42,19 +42,14 @@ FROM
   ${ctx.ref(tableSchema.entityTableName + "_version_" + params.eventSourceName)}
 WHERE
   valid_to IS NULL
-`).postOps(ctx => tableSchema.materialisation == "table" ? `
-  IF TRUE THEN /* Workaround - without putting the ALTER TABLE statements in a conditional block, although the script would execute without error, BigQuery query compilation unhelpfully returns an error on the line that attempts to add a primary key if a primary key already exists, ignoring the fact that a previous step in the script removes the primary key. */
-  ${data_functions.dropAllKeyConstraints(ctx, dataform)}
-  ALTER TABLE ${ctx.self()} ADD PRIMARY KEY(id) NOT ENFORCED;
-  ${data_functions.wait("2 SECOND")}
-    ${tableSchema.keys
-            // Only generate foreign key constraints for keys in the table that have the foreignKeyTable parameter set and when referential integrity checks are enabled at either key or eventDataSource level
-            .filter(key => key.foreignKeyTable && (key.foreignKeyName == "id" || !key.foreignKeyName))
-            .map(
-              key => `ALTER TABLE ${ctx.self()} ADD CONSTRAINT ${key.alias || key.keyName}_relationship FOREIGN KEY(${key.alias || key.keyName}) REFERENCES ${ctx.ref(key.foreignKeyTable + "_latest_" + params.eventSourceName)}(id) NOT ENFORCED;
-              ${data_functions.wait("2 SECOND")}`
-              ).join('\n')}
-
-  END IF;
-    ` : ``))
+`)
+.postOps(ctx => tableSchema.materialisation == "table" ? data_functions.setKeyConstraints(ctx, dataform, {
+    primaryKey: "id",
+    foreignKeys: tableSchema.keys
+        .filter(key => key.foreignKeyTable && (key.foreignKeyName == "id" || !key.foreignKeyName))
+            .map(key => {return {
+                keyInThisTable: key.alias || key.keyName,
+                foreignTable: key.foreignKeyTable + "_latest_" + params.eventSourceName
+                }})
+    }) : ``))
 }

--- a/includes/flattened_entity_version.js
+++ b/includes/flattened_entity_version.js
@@ -141,11 +141,10 @@ FROM (
 FROM
   ${ctx.ref(params.eventSourceName + "_entity_version")}
 WHERE
-  entity_table_name = "${tableSchema.entityTableName}")`).postOps(ctx => tableSchema.materialisation == "table" ? `
-  IF TRUE THEN /* Workaround - without putting the ALTER TABLE statements in a conditional block, although the script would execute without error, BigQuery query compilation unhelpfully returns an error on the line that attempts to add a primary key if a primary key already exists, ignoring the fact that a previous step in the script removes the primary key. */
-  ${data_functions.dropAllKeyConstraints(ctx, dataform)}
-  ALTER TABLE ${ctx.self()} ADD PRIMARY KEY(id, valid_from) NOT ENFORCED;
-  END IF;
-    ` : ``)
-    })
+  entity_table_name = "${tableSchema.entityTableName}")`)
+.postOps(ctx => tableSchema.materialisation == "table" ? data_functions.setKeyConstraints(ctx, dataform, {
+    primaryKey: "id, valid_from"
+    }) : ``)
+})
 }
+    

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,20 @@
     "packages": {
         "": {
             "dependencies": {
-                "@dataform/core": "2.8.4"
+                "@dataform/core": "2.9.0"
             }
         },
         "node_modules/@dataform/core": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-2.8.4.tgz",
-            "integrity": "sha512-Q73D5BwviHzZmTICVoUPati3ellySuF7hsyL3h27vez+aMXb7dqZJiphHj5Pkg7NQFS/F++5my9pPMuYqf6zbQ=="
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-2.9.0.tgz",
+            "integrity": "sha512-S0aJMpof0uxL7Sodi7CH3ewlN83NFm0kRDvWoBfc0prw/a5wVIAY1LZWeg/6icqKPUw5b5xWn2ub82YrD8zVTg=="
         }
     },
     "dependencies": {
         "@dataform/core": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-2.8.4.tgz",
-            "integrity": "sha512-Q73D5BwviHzZmTICVoUPati3ellySuF7hsyL3h27vez+aMXb7dqZJiphHj5Pkg7NQFS/F++5my9pPMuYqf6zbQ=="
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-2.9.0.tgz",
+            "integrity": "sha512-S0aJMpof0uxL7Sodi7CH3ewlN83NFm0kRDvWoBfc0prw/a5wVIAY1LZWeg/6icqKPUw5b5xWn2ub82YrD8zVTg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "@dataform/core": "2.8.4"
+        "@dataform/core": "2.9.0"
     }
 }


### PR DESCRIPTION
Also refactor all key constraint setting scripts into an exported function, and handle weirdly formatted boolean strings in data_functions.eventDataExtract() - mostly for legacy analytics data from the old C# version of Apply for ITT