### PR TITLE
Missing deletion event repair bugfixes

### DIFF
--- a/includes/entity_table_check_import.js
+++ b/includes/entity_table_check_import.js
@@ -25,8 +25,7 @@ module.exports = (params) => {
                     checksum_calculated_at: "The time that database_checksum was calculated.",
                     final_import_event_received_at: "The time that the final import_entity or import_entity_table_check event was received from dfe-analytics for this import",
                     order_column: "The column used to order entity IDs as part of the checksum calculation algorithm for both database_checksum and bigquery_checksum. May be updated_at (default), created_at or id.",
-                    bigquery_row_count: "The number of unique IDs for this entity in the group of import_entity events with this import_id in the events table. ",
-                    imported_entity_ids: "Array of UIDs for entities included in this import."
+                    bigquery_row_count: "The number of unique IDs for this entity in the group of import_entity events with this import_id in the events table. "
                 }
             }
         ).tags([params.eventSourceName.toLowerCase()])
@@ -89,7 +88,6 @@ module.exports = (params) => {
             check.import_id,
             check.row_count AS database_row_count,
             COUNT(DISTINCT latest_import_event.id) AS bigquery_row_count,
-            ARRAY_AGG(latest_import_event.id IGNORE NULLS) AS imported_entity_ids,
             check.checksum AS database_checksum,
             check.order_column,
             TO_HEX(MD5(STRING_AGG(${sortField == "id" ? `latest_import_event.id` : `CASE WHEN TIMESTAMP_TRUNC(${sortField}, MILLISECOND) < TIMESTAMP_TRUNC(check.checksum_calculated_at, MILLISECOND) THEN latest_import_event.id END`}, ""
@@ -135,12 +133,7 @@ module.exports = (params) => {
         ELSE
           /* Default to sorting by updated_at for backwards compatibility */
           imports_with_updated_at_metrics.bigquery_checksum
-        END AS bigquery_checksum,
-        CASE check.order_column
-            WHEN "created_at" THEN imports_with_created_at_metrics.imported_entity_ids
-            WHEN "id" THEN imports_with_id_metrics.imported_entity_ids
-            ELSE imports_with_updated_at_metrics.imported_entity_ids
-        END AS imported_entity_ids
+        END AS bigquery_checksum
       FROM
         check
       LEFT JOIN
@@ -154,6 +147,6 @@ module.exports = (params) => {
       USING (entity_table_name, import_id)`
         ).preOps(ctx => `
     DECLARE event_timestamp_checkpoint DEFAULT (
-        ${ctx.when(ctx.incremental(), `SELECT MAX(final_import_event_received_at) FROM ${ctx.self()}`, `SELECT TIMESTAMP("2000-01-01")`)});`
+        ${ctx.when(ctx.incremental(), `SELECT IFNULL(MAX(final_import_event_received_at), TIMESTAMP("2000-01-01")) FROM ${ctx.self()}`, `SELECT TIMESTAMP("2000-01-01")`)});`
   )
 }

--- a/includes/entity_version.js
+++ b/includes/entity_version.js
@@ -183,14 +183,31 @@ WHERE
             valid_to = apparently_deleted_before
             FROM (
             WITH
-                complete_import AS (
+                complete_import_with_ids AS (
                 SELECT
-                *
+                    import.import_id,
+                    import.entity_table_name,
+                    import.checksum_calculated_at,
+                    ARRAY_AGG(${data_functions.eventDataExtract("data", "id")} IGNORE NULLS) AS imported_entity_ids
                 FROM
                 ${ctx.ref("entity_table_check_import_" + params.eventSourceName)} AS import
+                LEFT JOIN ${"`" + params.bqProjectName + "." + params.bqDatasetName + "." + params.bqEventsTableName + "`"} AS import_event
+                ON
+                    import.import_id = import_event.event_tags[0]
+                    AND import.entity_table_name = import_event.entity_table_name
                 WHERE
-                database_checksum = bigquery_checksum
-                AND ARRAY_LENGTH(import.imported_entity_ids) > 0)
+                    import.database_checksum = import.bigquery_checksum
+                    AND import_event.event_type = "import_entity"
+                    AND ARRAY_LENGTH(import_event.event_tags) = 1
+                    AND DATE(import_event.occurred_at) >= DATE(event_timestamp_checkpoint)
+                    AND DATE(import.checksum_calculated_at) >= DATE(event_timestamp_checkpoint)
+                GROUP BY
+                    import.import_id,
+                    import.entity_table_name,
+                    import.checksum_calculated_at
+                HAVING
+                    ARRAY_LENGTH(imported_entity_ids) > 0
+                )
             SELECT
                 entity_version.entity_table_name,
                 entity_version.entity_id AS id_that_was_apparently_deleted,
@@ -198,7 +215,7 @@ WHERE
             FROM
                 ${ctx.self()} AS entity_version
             JOIN
-                complete_import AS import
+                complete_import_with_ids AS import
             ON
                 import.entity_table_name = entity_version.entity_table_name
                 AND import.checksum_calculated_at > entity_version.valid_from

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const version = "1.12.4";
+const version = "1.12.5";
 
 const parameterFunctions = require("./includes/parameter_functions");
 


### PR DESCRIPTION
- Fix entity_table_check_import not populating in incremental mode if empty
- Fix entity_table_check_import imported_entity_ids column breaching BQ 100MB per row data limit when used with services with tables with large numbers of rows