### PR TITLE
Collection additional data load reliability & hidden PII metrics

### DIFF
--- a/definitions/bat_register_test.js
+++ b/definitions/bat_register_test.js
@@ -4,7 +4,7 @@ const dfeAnalyticsDataform = require("../");
 
 dfeAnalyticsDataform({
     eventSourceName: "register",
-    bqDatasetName: "register_events_qa",
+    bqDatasetName: "register_events_production",
     bqEventsTableName: "events",
     urlRegex: "register-trainee-teachers.service.gov.uk",
     transformEntityEvents: true,
@@ -114,7 +114,7 @@ dfeAnalyticsDataform({
         {
             entityTableName: "courses",
             description: "",
-            hidePrimaryKey: true,
+            hidePrimaryKey: false,
             keys: [{
                 keyName: "accredited_body_code",
                 dataType: "string",
@@ -136,7 +136,7 @@ dfeAnalyticsDataform({
                 keyName: "level",
                 dataType: "string",
                 description: "level of the course",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "min_age",
                 dataType: "integer",
@@ -165,7 +165,7 @@ dfeAnalyticsDataform({
                 keyName: "full_time_start_date",
                 dataType: "date",
                 description: "Full time start date",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "full_time_end_date",
                 dataType: "date",
@@ -194,7 +194,7 @@ dfeAnalyticsDataform({
                 keyName: "summary",
                 dataType: "string",
                 description: "summary description of the course",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "uuid",
                 dataType: "string",
@@ -729,7 +729,7 @@ dfeAnalyticsDataform({
                 keyName: "disability_disclosure",
                 dataType: "string",
                 description: "",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "discarded_at",
                 dataType: "timestamp",
@@ -797,7 +797,7 @@ dfeAnalyticsDataform({
                 dataType: "string",
                 description: "Lead school urn",
                 foreignKeyTable: "schools",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "lead_school_not_applicable",
                 dataType: "boolean",
@@ -819,7 +819,7 @@ dfeAnalyticsDataform({
                 keyName: "progress",
                 dataType: "string",
                 description: "progress - various JSON pairs",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "provider_id",
                 dataType: "string",
@@ -854,7 +854,7 @@ dfeAnalyticsDataform({
                 keyName: "sex",
                 dataType: "string",
                 description: "Trainee sex",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "state",
                 dataType: "string",
@@ -883,7 +883,7 @@ dfeAnalyticsDataform({
                 keyName: "trn",
                 dataType: "string",
                 description: "Trainees's Teacher Reference Number",
-                hidden: true
+                hidden: false
             }, {
                 keyName: "withdraw_date",
                 dataType: "date",

--- a/includes/pipeline_snapshot.js
+++ b/includes/pipeline_snapshot.js
@@ -1,9 +1,9 @@
 module.exports = (version, params) => {
-    if ((!params.enableMonitoring) || dataform.projectConfig.schemaSuffix) {
+   // if ((!params.enableMonitoring) || dataform.projectConfig.schemaSuffix) {
         /* Don't send pipeline snapshot if monitoring is disabled (enableMonitoring is true by default)
         or if we're in a Dataform development workspace (schemaSuffix is null if we're in a development workspace) */
-        return true;
-    }
+    //    return true;
+    //}
     return operate("pipeline_snapshot_" + params.eventSourceName, ctx => [`
 BEGIN
 INSERT \`cross-teacher-services.monitoring.pipeline_snapshots\` (
@@ -22,17 +22,33 @@ INSERT \`cross-teacher-services.monitoring.pipeline_snapshots\` (
     dfe_analytics_dataform_parameters
     )
 WITH
-  entity_table_check_scheduled_metrics AS (
   ${params.transformEntityEvents ? `
+  entity_table_check_latest AS (
+  SELECT
+    *
+  FROM
+    ${ctx.ref("entity_table_check_scheduled_" + params.eventSourceName)}
+  QUALIFY
+    ROW_NUMBER() OVER (PARTITION BY entity_table_name ORDER BY checksum_calculated_at ASC) = 1
+  ),
+  entity_table_check_scheduled_metrics AS (
   SELECT
     COUNT(DISTINCT entity_table_name) > 0 AS checksum_enabled,
     COUNT(DISTINCT entity_table_name) AS number_of_tables,
     COUNT(DISTINCT CASE WHEN database_checksum = bigquery_checksum THEN entity_table_name END) AS number_of_tables_with_matching_checksums,
     SUM(database_row_count) AS number_of_rows,
-    SUM(CASE WHEN database_row_count > bigquery_row_count THEN database_row_count - bigquery_row_count ELSE 0 END) AS number_of_missing_rows,
-    SUM(CASE WHEN database_row_count < bigquery_row_count THEN bigquery_row_count - database_row_count ELSE 0 END) AS number_of_extra_rows
+    SUM(number_of_missing_rows) AS number_of_missing_rows,
+    SUM(number_of_extra_rows) AS number_of_extra_rows,
+    SUM(weekly_change_in_number_of_rows) AS weekly_change_in_number_of_rows,
+    SUM(weekly_change_in_number_of_missing_rows) AS weekly_change_in_number_of_missing_rows,
+    SUM(weekly_change_in_number_of_extra_rows) AS weekly_change_in_number_of_extra_rows,
+    MAX(error_rate) AS largest_error_rate_for_any_table,
+    MAX_BY(entity_table_name, error_rate) AS table_with_largest_error_rate,
+    MAX(twelve_week_projected_error_rate) AS largest_twelve_week_projected_error_rate_for_any_table,
+    MAX_BY(entity_table_name, twelve_week_projected_error_rate) AS table_with_largest_twelve_week_projected_error_rate
   FROM
-    ${ctx.ref("entity_table_check_scheduled_" + params.eventSourceName)} ` : `
+    entity_table_check_latest ` : `
+  entity_table_check_scheduled_metrics AS (
     SELECT
     CAST(NULL AS BOOL) AS checksum_enabled,
     CAST(NULL AS INT64) AS number_of_tables,
@@ -48,19 +64,43 @@ WITH
   FROM
     ${ctx.ref("dfe_analytics_configuration_" + params.eventSourceName)}
   WHERE
-    valid_to IS NULL )
+    valid_to IS NULL ),
+  events_table_metrics AS (
+    SELECT
+      LOGICAL_OR(ARRAY_LENGTH(hidden_data) > 0) AS hidden_pii_streamed_within_the_last_week
+    FROM
+      ${ctx.ref("events_" + params.eventSourceName)}
+    WHERE
+      DATE(occurred_at) >= CURRENT_DATE - 7
+  )
 SELECT
   CURRENT_TIMESTAMP AS workflow_executed_at,
   "${params.bqProjectName}" AS gcp_project_name,
   "${params.eventSourceName}" AS event_source_name,
   "${dataform.projectConfig.defaultSchema + (dataform.projectConfig.schemaSuffix ? "_" + dataform.projectConfig.schemaSuffix : "")}" AS output_dataset_name,
-  dfe_analytics_configuration_metrics.*,
+  dfe_analytics_configuration_metrics.dfe_analytics_version,
   "${version}" AS dfe_analytics_dataform_version,
-  entity_table_check_scheduled_metrics.*,
-  """${JSON.stringify(params)}""" AS dfe_analytics_dataform_parameters
+  entity_table_check_scheduled_metrics.checksum_enabled,
+  entity_table_check_scheduled_metrics.number_of_tables,
+  entity_table_check_scheduled_metrics.number_of_tables_with_matching_checksums,
+  entity_table_check_scheduled_metrics.number_of_rows,
+  entity_table_check_scheduled_metrics.number_of_missing_rows,
+  entity_table_check_scheduled_metrics.number_of_extra_rows,
+  """${JSON.stringify(params)}""" AS dfe_analytics_dataform_parameters,
+  /* New parameters from dfe-analytics-dataform v2.0.0 below */
+  events_table_metrics.hidden_pii_streamed_within_the_last_week,
+  ${params.hiddenPolicyTagLocation ? "TRUE" : "FALSE"} AS hidden_pii_configured,
+  entity_table_check_scheduled_metrics.weekly_change_in_number_of_rows,
+  entity_table_check_scheduled_metrics.weekly_change_in_number_of_missing_rows,
+  entity_table_check_scheduled_metrics.weekly_change_in_number_of_extra_rows,
+  entity_table_check_scheduled_metrics.largest_error_rate_for_any_table,
+  entity_table_check_scheduled_metrics.table_with_largest_error_rate,
+  entity_table_check_scheduled_metrics.largest_twelve_week_projected_error_rate_for_any_table,
+  entity_table_check_scheduled_metrics.table_with_largest_twelve_week_projected_error_rate
 FROM
   entity_table_check_scheduled_metrics,
-  dfe_analytics_configuration_metrics;
+  dfe_analytics_configuration_metrics,
+  events_table_metrics;
 EXCEPTION WHEN ERROR THEN
   IF LOWER(@@error.message) LIKE "%access denied%" THEN RAISE USING MESSAGE = "Your Dataform service account does not have the required permissions to send data to the monitoring.pipeline_snapshots table in the cross-teacher-services GCP project. Please ask the Data & Insights team on Slack (#twd_data_insights) to give your Dataform service account the BigQuery Data Editor role on this table.";
   ELSE RAISE;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const version = "1.13.0";
+const version = "2.0.0";
 
 const parameterFunctions = require("./includes/parameter_functions");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,20 @@
         "": {
             "name": "dfe-analytics-dataform",
             "dependencies": {
-                "@dataform/core": "3.0.0-beta.5"
+                "@dataform/core": "3.0.0"
             }
         },
         "node_modules/@dataform/core": {
-            "version": "3.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0-beta.5.tgz",
-            "integrity": "sha512-t9i0lIhfHG1gNZY/sYokZ5kpzsYWMTPPBa2r1+ZZaY3Um8SFK7rc84ckGlvtv81n4r7U4yunaz9pMpqNb4Gyng=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0.tgz",
+            "integrity": "sha512-MORO8ADZkkPfAHH0S/jb3o/6HOYT4klw+hCgyHkNInFTnIYAN+zzgHc9++FrtXNyer0MvnZ351XTBveIVw7tcg=="
         }
     },
     "dependencies": {
         "@dataform/core": {
-            "version": "3.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0-beta.5.tgz",
-            "integrity": "sha512-t9i0lIhfHG1gNZY/sYokZ5kpzsYWMTPPBa2r1+ZZaY3Um8SFK7rc84ckGlvtv81n4r7U4yunaz9pMpqNb4Gyng=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0.tgz",
+            "integrity": "sha512-MORO8ADZkkPfAHH0S/jb3o/6HOYT4klw+hCgyHkNInFTnIYAN+zzgHc9++FrtXNyer0MvnZ351XTBveIVw7tcg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dfe-analytics-dataform",
     "dependencies": {
-        "@dataform/core": "3.0.0-beta.5"
+        "@dataform/core": "3.0.0"
     }
 }


### PR DESCRIPTION
- Collection additional data load reliability & hidden PII metrics in pipeline_snapshot operation
- Bump version to v2.0.0
- Make entity_table_check_scheduled track the last 7 days of data, not just yesterday

After merging we need to:
1. Add the new fields to cross-teacher-services.monitoring.pipeline_snapshots with correct data types and metadata
2. Redesign the dashboard to use some/all of these new fields