### PR TITLE
Fix inconsistent attempts to snapshot entity-related metrics in pipeline_snapshot when transformEntityEvents is not true

### DIFF
--- a/includes/pipeline_snapshot.js
+++ b/includes/pipeline_snapshot.js
@@ -22,13 +22,13 @@ INSERT \`cross-teacher-services.monitoring.pipeline_snapshots\` (
     dfe_analytics_dataform_parameters,
     hidden_pii_streamed_within_the_last_week,
     hidden_pii_configured,
-    weekly_change_in_number_of_rows,
+    ${params.transformEntityEvents ? `` : `weekly_change_in_number_of_rows,
     weekly_change_in_number_of_missing_rows,
     weekly_change_in_number_of_extra_rows,
     largest_error_rate_for_any_table,
     table_with_largest_error_rate,
     largest_twelve_week_projected_error_rate_for_any_table,
-    table_with_largest_twelve_week_projected_error_rate
+    table_with_largest_twelve_week_projected_error_rate`}
     )
 WITH
   ${params.transformEntityEvents ? `
@@ -99,13 +99,13 @@ SELECT
   /* New parameters from dfe-analytics-dataform v2.0.0 below */
   events_table_metrics.hidden_pii_streamed_within_the_last_week,
   ${params.hiddenPolicyTagLocation ? "TRUE" : "FALSE"} AS hidden_pii_configured,
-  entity_table_check_scheduled_metrics.weekly_change_in_number_of_rows,
+  ${params.transformEntityEvents ? `` : `entity_table_check_scheduled_metrics.weekly_change_in_number_of_rows,
   entity_table_check_scheduled_metrics.weekly_change_in_number_of_missing_rows,
   entity_table_check_scheduled_metrics.weekly_change_in_number_of_extra_rows,
   entity_table_check_scheduled_metrics.largest_error_rate_for_any_table,
   entity_table_check_scheduled_metrics.table_with_largest_error_rate,
   entity_table_check_scheduled_metrics.largest_twelve_week_projected_error_rate_for_any_table,
-  entity_table_check_scheduled_metrics.table_with_largest_twelve_week_projected_error_rate
+  entity_table_check_scheduled_metrics.table_with_largest_twelve_week_projected_error_rate`}
 FROM
   entity_table_check_scheduled_metrics,
   dfe_analytics_configuration_metrics,


### PR DESCRIPTION
This was causing pipeline_snapshot to fail on  the teaching-qualifications pipeline