### PR TITLE
Update to session_details table to include UTM tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const version = "2.3.0";
+const version = "2.3.1";
 
 const parameterFunctions = require("./includes/parameter_functions");
 


### PR DESCRIPTION
Added 3 fields utm_source, utm_medium and utm_campaign.

These track utm tags associated with the first page in each session. This will allow more accurate tracking of comms and marketing campaigns.