### PR TITLE
Deletion repair mechanism fixes

### DIFF
--- a/definitions/bat_apply_test.js
+++ b/definitions/bat_apply_test.js
@@ -3,7 +3,7 @@
 const dfeAnalyticsDataform = require("../");
 
 dfeAnalyticsDataform({
-    disabled: false,
+    disabled: true,
     transformEntityEvents: true,
     eventSourceName: "apply",
     bqProjectName: "rugged-abacus-218110",

--- a/definitions/bat_register_test.js
+++ b/definitions/bat_register_test.js
@@ -3,7 +3,7 @@
 const dfeAnalyticsDataform = require("../");
 
 dfeAnalyticsDataform({
-    disabled: true,
+    disabled: false,
     eventSourceName: "register",
     bqDatasetName: "register_events_production",
     bqEventsTableName: "events",
@@ -91,6 +91,10 @@ dfeAnalyticsDataform({
                 keyName: "errored_on_type",
                 dataType: "string",
                 description: "The type of the error."
+            }, {
+                keyName: "error_type",
+                dataType: "string",
+                description: "The type of error on the row "
             }, {
                 keyName: "message",
                 dataType: "string",
@@ -508,7 +512,8 @@ dfeAnalyticsDataform({
                     keyName: "user_id",
                     dataType: "string",
                     description: "Unique id of the user."
-                }]
+                }
+            ]
         },
         {
             entityTableName: "lead_school_users",
@@ -583,6 +588,23 @@ dfeAnalyticsDataform({
                 dataType: "string",
                 description: ""
             }]
+        },
+        {
+            entityTableName: "potential_duplicate_trainees",
+            description: "",
+            materialisation: "view",
+            keys: [{
+                    keyName: "group_id",
+                    dataType: "string",
+                    description: ""
+                },
+                {
+                    keyName: "trainee_id",
+                    dataType: "string",
+                    description: "",
+                    foreignKeyTable: "trainees"
+                }
+            ]
         },
         {
             entityTableName: "provider_users",
@@ -663,10 +685,6 @@ dfeAnalyticsDataform({
                 keyName: "urn",
                 dataType: "string",
                 description: ""
-            }, {
-                keyName: "lead_school",
-                dataType: "boolean",
-                description: ""
             }]
         },
         {
@@ -705,277 +723,293 @@ dfeAnalyticsDataform({
             description: "",
             dataFreshnessDays: 3,
             keys: [{
-                keyName: "apply_application_id",
-                dataType: "string",
-                description: "Foreign key to apply_applications identifier register_apply_applications .id",
-                foreignKeyTable: "apply_applications"
-            }, {
-                keyName: "application_choice_id",
-                dataType: "string",
-                description: "The id of application choice. Foreign key connecting to apply_applications.apply_id",
-                foreignKeyTable: "apply_applications",
-                foreignKeyName: "apply_id"
-            }, {
-                keyName: "applying_for_bursary",
-                dataType: "string",
-                description: "Trainee is applying for a bursary (true) or not (false)"
-            }, {
-                keyName: "applying_for_grant",
-                dataType: "string",
-                description: "Trainee is applying for a grant (true) or not (false)"
-            }, {
-                keyName: "applying_for_scholarship",
-                dataType: "string",
-                description: "Trainee is applying for a scholarship (true) or not (false)"
-            }, {
-                keyName: "awarded_at",
-                dataType: "timestamp",
-                description: "Date QTS or EYTS was awarded"
-            }, {
-                keyName: "bursary_tier",
-                dataType: "string",
-                description: "Bursary tier. Only available for years where bursaries were paid on a tiered basis"
-            }, {
-                keyName: "commencement_status",
-                dataType: "string",
-                description: "Indicates if trainee started on time (0), late (1), or have not started yet (2)"
-            }, {
-                keyName: "trainee_start_date",
-                dataType: "date",
-                description: "Date the trainee started their ITT course"
-            }, {
-                keyName: "course_allocation_subject_id",
-                dataType: "string",
-                description: "",
-                foreignKeyTable: "allocation_subjects"
-            }, {
-                keyName: "course_education_phase",
-                dataType: "string",
-                description: "Indicates if a course is primary (0) or secondary (1)"
-            }, {
-                keyName: "course_min_age",
-                dataType: "string",
-                description: "Lower age range for course"
-            }, {
-                keyName: "course_max_age",
-                dataType: "string",
-                description: "Upper age range for course"
-            }, {
-                keyName: "course_subject_one",
-                dataType: "string",
-                description: "Course subject on which allocation subject is based"
-            }, {
-                keyName: "course_subject_two",
-                dataType: "string",
-                description: "Additional course subject"
-            }, {
-                keyName: "course_subject_three",
-                dataType: "string",
-                description: "Additional course subject"
-            }, {
-                keyName: "course_uuid",
-                dataType: "string",
-                description: "Foreign key to courses entity uuid, register_courses.uuid"
-            }, {
-                keyName: "defer_date",
-                dataType: "date",
-                description: "Date trainee was deferred"
-            }, {
-                keyName: "disability_disclosure",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "discarded_at",
-                dataType: "timestamp",
-                description: "Timestamp at which a trainee record was discarded"
-            }, {
-                keyName: "diversity_disclosure",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "dormancy_dttp_id",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "dttp_id",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "dttp_update_sha",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "ebacc",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "employing_school_id",
-                dataType: "string",
-                description: "Employing school urn",
-                foreignKeyTable: "schools"
-            }, {
-                keyName: "employing_school_not_applicable",
-                dataType: "boolean",
-                description: "Employing school not applicable, true or false"
-            }, {
-                keyName: "end_academic_cycle_id",
-                dataType: "string",
-                description: "",
-                foreignKeyTable: "academic_cycles"
-            }, {
-                keyName: "hesa_id",
-                dataType: "string",
-                description: "HESA unique student identifier. Presence of this implies an HEI trainee."
-            }, {
-                keyName: "hesa_editable",
-                dataType: "boolean",
-                description: "TRUE if this trainee is editable in HESA"
-            }, {
-                keyName: "hesa_updated_at",
-                dataType: "timestamp",
-                description: "Timestamp of last HESA update"
-            }, {
-                keyName: "iqts_country",
-                dataType: "string",
-                description: "Country where training is being undertaken for trainees on iQTS route"
-            }, {
-                keyName: "itt_end_date",
-                dataType: "date",
-                description: "ITT course end date"
-            }, {
-                keyName: "itt_start_date",
-                dataType: "date",
-                description: "ITT course start date"
-            }, {
-                keyName: "lead_partner_id",
-                dataType: "string",
-                description: "Lead partner",
-            }, {
-                keyName: "lead_partner_not_applicable",
-                dataType: "boolean",
-                description: "Lead partner not applicable, true or false",
-            }, {
-                keyName: "lead_school_id",
-                dataType: "string",
-                description: "Lead school urn",
-                foreignKeyTable: "schools"
-            }, {
-                keyName: "lead_school_not_applicable",
-                dataType: "boolean",
-                description: "Lead school not applicable, true or false"
-            }, {
-                keyName: "outcome_date",
-                dataType: "date",
-                description: ""
-            }, {
-                keyName: "placement_assignment_dttp_id",
-                dataType: "string",
-                description: "",
-                alias: "placement_assignment_dttp_id_uuid"
-            }, {
-                keyName: "placement_detail",
-                dataType: "string",
-                description: "",
-            }, {
-                keyName: "progress",
-                dataType: "string",
-                description: "progress - various JSON pairs"
-            }, {
-                keyName: "provider_id",
-                dataType: "string",
-                description: "Registers unique provider identifier. Not used by other services.",
-                foreignKeyTable: "providers"
-            }, {
-                keyName: "recommended_for_award_at",
-                dataType: "timestamp",
-                description: ""
-            }, {
-                keyName: "record_source",
-                dataType: "string",
-                description: "Source of where the trainee record originated from i.e. manual, apply, dttp, hesa_collection, hesa_trn_data"
-            }, {
-                keyName: "region",
-                dataType: "string",
-                description: "Trainee's region"
-            }, {
-                keyName: "reinstate_date",
-                dataType: "date",
-                description: ""
-            }, {
-                keyName: "slug",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "start_academic_cycle_id",
-                dataType: "string",
-                description: "",
-                foreignKeyTable: "academic_cycles"
-            }, {
-                keyName: "sex",
-                dataType: "string",
-                description: "Trainee sex"
-            }, {
-                keyName: "state",
-                dataType: "string",
-                description: "Current status of trainee - draft(0), submitted_for_trn (1), trn_received (2), recommended_for_award (3), withdrawn (4), deferred (5), awarded(6)"
-            }, {
-                keyName: "study_mode",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "submission_ready",
-                dataType: "boolean",
-                description: ""
-            }, {
-                keyName: "submitted_for_trn_at",
-                dataType: "timestamp",
-                description: "submitted for teacher reference number at"
-            }, {
-                keyName: "training_initiative",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "training_route",
-                dataType: "string",
-                description: "training route - assessment_only (0),provider_led_postgrad (1), early_years_undergrad (2), school_direct_tuition_fee (3),school_direct_salaried (4), pg_teaching_apprenticeship (5), early_years_assessment_only (6), early_years_salaried (7), early_years_postgrad (8), provider_led_undergrad (9), opt_in_undergrad (10), hpitt_postgrad (11), iqts (12)"
-            }, {
-                keyName: "trn",
-                dataType: "string",
-                description: "Trainees's Teacher Reference Number",
-                hidden: true
-            }, {
-                keyName: "withdraw_date",
-                dataType: "date",
-                description: "Date trainee withdrew from course"
-            }, {
-                keyName: "withdraw_reasons_details",
-                dataType: "string",
-                description: "Details of the reason a trainee withdrew from course"
-            }, {
-                keyName: "withdraw_reasons_dfe_details",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "hesa_trn_submission_id",
-                dataType: "string",
-                description: ""
-            }, {
-                keyName: "created_from_hesa",
-                dataType: "boolean",
-                description: ""
-            }, {
-                keyName: "created_from_dttp",
-                dataType: "boolean",
-                description: ""
-            }, {
-                keyName: "slug_sent_to_dqt_at",
-                dataType: "timestamp",
-                description: ""
-            }, {
-                keyName: "previous_hesa_id",
-                dataType: "string",
-                description: "Value immediately before this update of: HESA unique student identifier. Presence of this implies an HEI trainee."
-            }]
+                    keyName: "apply_application_id",
+                    dataType: "string",
+                    description: "Foreign key to apply_applications identifier register_apply_applications .id",
+                    foreignKeyTable: "apply_applications"
+                }, {
+                    keyName: "application_choice_id",
+                    dataType: "string",
+                    description: "The id of application choice. Foreign key connecting to apply_applications.apply_id",
+                    foreignKeyTable: "apply_applications",
+                    foreignKeyName: "apply_id"
+                }, {
+                    keyName: "applying_for_bursary",
+                    dataType: "string",
+                    description: "Trainee is applying for a bursary (true) or not (false)"
+                }, {
+                    keyName: "applying_for_grant",
+                    dataType: "string",
+                    description: "Trainee is applying for a grant (true) or not (false)"
+                }, {
+                    keyName: "applying_for_scholarship",
+                    dataType: "string",
+                    description: "Trainee is applying for a scholarship (true) or not (false)"
+                }, {
+                    keyName: "awarded_at",
+                    dataType: "timestamp",
+                    description: "Date QTS or EYTS was awarded"
+                }, {
+                    keyName: "bursary_tier",
+                    dataType: "string",
+                    description: "Bursary tier. Only available for years where bursaries were paid on a tiered basis"
+                }, {
+                    keyName: "commencement_status",
+                    dataType: "string",
+                    description: "Indicates if trainee started on time (0), late (1), or have not started yet (2)"
+                }, {
+                    keyName: "trainee_start_date",
+                    dataType: "date",
+                    description: "Date the trainee started their ITT course"
+                }, {
+                    keyName: "course_allocation_subject_id",
+                    dataType: "string",
+                    description: "",
+                    foreignKeyTable: "allocation_subjects"
+                }, {
+                    keyName: "course_education_phase",
+                    dataType: "string",
+                    description: "Indicates if a course is primary (0) or secondary (1)"
+                }, {
+                    keyName: "course_min_age",
+                    dataType: "string",
+                    description: "Lower age range for course"
+                }, {
+                    keyName: "course_max_age",
+                    dataType: "string",
+                    description: "Upper age range for course"
+                }, {
+                    keyName: "course_subject_one",
+                    dataType: "string",
+                    description: "Course subject on which allocation subject is based"
+                }, {
+                    keyName: "course_subject_two",
+                    dataType: "string",
+                    description: "Additional course subject"
+                }, {
+                    keyName: "course_subject_three",
+                    dataType: "string",
+                    description: "Additional course subject"
+                }, {
+                    keyName: "course_uuid",
+                    dataType: "string",
+                    description: "Foreign key to courses entity uuid, register_courses.uuid"
+                },
+                {
+                    keyName: "date_of_birth",
+                    dataType: "string",
+                    description: "Date of birth of trainee",
+                    hidden: true
+                },
+                {
+                    keyName: "defer_date",
+                    dataType: "date",
+                    description: "Date trainee was deferred"
+                }, {
+                    keyName: "disability_disclosure",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "discarded_at",
+                    dataType: "timestamp",
+                    description: "Timestamp at which a trainee record was discarded"
+                }, {
+                    keyName: "diversity_disclosure",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "dormancy_dttp_id",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "dttp_id",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "dttp_update_sha",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "ebacc",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "email",
+                    dataType: "string",
+                    description: "Email address of the trainee",
+                    hidden: true
+                }, {
+                    keyName: "employing_school_id",
+                    dataType: "string",
+                    description: "Employing school urn",
+                    foreignKeyTable: "schools"
+                }, {
+                    keyName: "employing_school_not_applicable",
+                    dataType: "boolean",
+                    description: "Employing school not applicable, true or false"
+                }, {
+                    keyName: "end_academic_cycle_id",
+                    dataType: "string",
+                    description: "",
+                    foreignKeyTable: "academic_cycles"
+                }, {
+                    keyName: "first_names",
+                    dataType: "string",
+                    description: "First name of the trainee",
+                    hidden: true
+                }, {
+                    keyName: "hesa_id",
+                    dataType: "string",
+                    description: "HESA unique student identifier. Presence of this implies an HEI trainee."
+                }, {
+                    keyName: "hesa_editable",
+                    dataType: "boolean",
+                    description: "TRUE if this trainee is editable in HESA"
+                }, {
+                    keyName: "hesa_updated_at",
+                    dataType: "timestamp",
+                    description: "Timestamp of last HESA update"
+                }, {
+                    keyName: "iqts_country",
+                    dataType: "string",
+                    description: "Country where training is being undertaken for trainees on iQTS route"
+                }, {
+                    keyName: "itt_end_date",
+                    dataType: "date",
+                    description: "ITT course end date"
+                }, {
+                    keyName: "itt_start_date",
+                    dataType: "date",
+                    description: "ITT course start date"
+                },
+                {
+                    keyName: "last_name",
+                    dataType: "string",
+                    description: "Last name of the trainee",
+                    hidden: true
+                },
+                {
+                    keyName: "lead_partner_id",
+                    dataType: "string",
+                    description: "Lead partner",
+                }, {
+                    keyName: "lead_partner_not_applicable",
+                    dataType: "boolean",
+                    description: "Lead partner not applicable, true or false",
+                }, {
+                    keyName: "outcome_date",
+                    dataType: "date",
+                    description: ""
+                }, {
+                    keyName: "placement_assignment_dttp_id",
+                    dataType: "string",
+                    description: "",
+                    alias: "placement_assignment_dttp_id_uuid"
+                }, {
+                    keyName: "placement_detail",
+                    dataType: "string",
+                    description: "",
+                }, {
+                    keyName: "progress",
+                    dataType: "string",
+                    description: "progress - various JSON pairs"
+                }, {
+                    keyName: "provider_id",
+                    dataType: "string",
+                    description: "Registers unique provider identifier. Not used by other services.",
+                    foreignKeyTable: "providers"
+                }, {
+                    keyName: "recommended_for_award_at",
+                    dataType: "timestamp",
+                    description: ""
+                }, {
+                    keyName: "record_source",
+                    dataType: "string",
+                    description: "Source of where the trainee record originated from i.e. manual, apply, dttp, hesa_collection, hesa_trn_data"
+                }, {
+                    keyName: "region",
+                    dataType: "string",
+                    description: "Trainee's region"
+                }, {
+                    keyName: "reinstate_date",
+                    dataType: "date",
+                    description: ""
+                }, {
+                    keyName: "slug",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "start_academic_cycle_id",
+                    dataType: "string",
+                    description: "",
+                    foreignKeyTable: "academic_cycles"
+                }, {
+                    keyName: "sex",
+                    dataType: "string",
+                    description: "Trainee sex"
+                }, {
+                    keyName: "state",
+                    dataType: "string",
+                    description: "Current status of trainee - draft(0), submitted_for_trn (1), trn_received (2), recommended_for_award (3), withdrawn (4), deferred (5), awarded(6)"
+                }, {
+                    keyName: "study_mode",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "submission_ready",
+                    dataType: "boolean",
+                    description: ""
+                }, {
+                    keyName: "submitted_for_trn_at",
+                    dataType: "timestamp",
+                    description: "submitted for teacher reference number at"
+                }, {
+                    keyName: "training_initiative",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "training_route",
+                    dataType: "string",
+                    description: "training route - assessment_only (0),provider_led_postgrad (1), early_years_undergrad (2), school_direct_tuition_fee (3),school_direct_salaried (4), pg_teaching_apprenticeship (5), early_years_assessment_only (6), early_years_salaried (7), early_years_postgrad (8), provider_led_undergrad (9), opt_in_undergrad (10), hpitt_postgrad (11), iqts (12)"
+                }, {
+                    keyName: "trn",
+                    dataType: "string",
+                    description: "Trainees's Teacher Reference Number",
+                    hidden: true
+                }, {
+                    keyName: "withdraw_date",
+                    dataType: "date",
+                    description: "Date trainee withdrew from course"
+                }, {
+                    keyName: "withdraw_reasons_details",
+                    dataType: "string",
+                    description: "Details of the reason a trainee withdrew from course"
+                }, {
+                    keyName: "withdraw_reasons_dfe_details",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "hesa_trn_submission_id",
+                    dataType: "string",
+                    description: ""
+                }, {
+                    keyName: "created_from_hesa",
+                    dataType: "boolean",
+                    description: ""
+                }, {
+                    keyName: "created_from_dttp",
+                    dataType: "boolean",
+                    description: ""
+                }, {
+                    keyName: "slug_sent_to_dqt_at",
+                    dataType: "timestamp",
+                    description: ""
+                }, {
+                    keyName: "previous_hesa_id",
+                    dataType: "string",
+                    description: "Value immediately before this update of: HESA unique student identifier. Presence of this implies an HEI trainee."
+                }
+            ]
         },
         {
             entityTableName: "trainee_withdrawal_reasons",
@@ -1008,7 +1042,8 @@ dfeAnalyticsDataform({
             keys: [{
                 keyName: "dfe_sign_in_uid",
                 dataType: "string",
-                description: "Anonymised DfE Sign-in UID. Can be joined on to the anonymised sign_in_uid fields in the Publish user table and Apply provider_users and support_users tables."
+                description: "DfE Sign-in UID. Can be joined on to the anonymised sign_in_uid fields in the Publish user table and Apply provider_users and support_users tables.",
+                hidden: true
             }, {
                 keyName: "discarded_at",
                 dataType: "timestamp",
@@ -1029,6 +1064,35 @@ dfeAnalyticsDataform({
                 keyName: "welcome_email_sent_at",
                 dataType: "timestamp",
                 description: ""
+            }]
+        },
+        {
+            entityTableName: "sign_offs",
+            description: "",
+            keys: [{
+                keyName: "id",
+                dataType: "string",
+                description: "",
+                alias: "sign_off_id",
+            }, {
+                keyName: "sign_off_type",
+                dataType: "string",
+                description: ""
+            }, {
+                keyName: "academic_cycle_id",
+                dataType: "string",
+                description: "",
+                foreignKeyTable: "academic_cycles"
+            }, {
+                keyName: "provider_id",
+                dataType: "string",
+                description: "",
+                foreignKeyTable: "providers"
+            }, {
+                keyName: "user_id",
+                dataType: "string",
+                description: "",
+                foreignKeyTable: "users"
             }]
         }
     ]

--- a/includes/entity_version.js
+++ b/includes/entity_version.js
@@ -176,6 +176,7 @@ WHERE
   )`).preOps(ctx => `DECLARE event_timestamp_checkpoint DEFAULT (
         ${ctx.when(ctx.incremental(), `SELECT MAX(valid_to) FROM ${ctx.self()}`, `SELECT TIMESTAMP("2018-01-01")`)}
       )`)
+        
         .postOps(ctx => `${data_functions.setKeyConstraints(ctx, dataform, {
             primaryKey: "entity_id, valid_from, entity_table_name"
             })}
@@ -200,7 +201,7 @@ WHERE
                 valid_to = apparently_deleted_before,
                 entity_table_name_and_valid_to_partition_number = ABS(MOD(FARM_FINGERPRINT(apparently_deleted_entity.entity_table_name), 999)) + IF(apparently_deleted_entity.apparently_deleted_before IS NULL,0,1000)
             FROM (
-                WITH
+                    WITH
                     entity_table_name_with_primary_key AS (
                         SELECT
                             entity_table_name,
@@ -212,6 +213,17 @@ WHERE
                                 }).join(',\n')}
                             ])
                     ),
+                    complete_import_with_primary_key AS (
+                        SELECT import.import_id,
+                        import.entity_table_name,
+                        import.checksum_calculated_at,
+                        entity_table_name_with_primary_key.primary_key
+                        FROM ${ctx.ref("entity_table_check_import_" + params.eventSourceName)} AS import
+                        JOIN
+                        entity_table_name_with_primary_key USING(entity_table_name)
+                        WHERE import.database_checksum = import.bigquery_checksum
+                        AND DATE(import.checksum_calculated_at) >= DATE(event_timestamp_checkpoint)
+                    ),
                     imported_entity AS (
                     /* All entities in all imports that have not yet been processed, where checksums match for the given entity_table_name */
                     SELECT
@@ -220,9 +232,7 @@ WHERE
                         import.checksum_calculated_at,
                         imported_entity_id
                     FROM
-                        ${ctx.ref("entity_table_check_import_" + params.eventSourceName)} AS import
-                    LEFT JOIN
-                        entity_table_name_with_primary_key USING(entity_table_name)
+                        complete_import_with_primary_key AS import
                     LEFT JOIN
                         ${"`" + params.bqProjectName + "." + params.bqDatasetName + "." + params.bqEventsTableName + "`"} AS import_event
                     ON
@@ -233,13 +243,11 @@ WHERE
                     LEFT JOIN
                         UNNEST(combined_data.value) AS imported_entity_id
                     ON
-                        combined_data.KEY = entity_table_name_with_primary_key.primary_key
+                        combined_data.KEY = import.primary_key
                     WHERE
-                        import.database_checksum = import.bigquery_checksum
-                        AND import_event.event_type = "import_entity"
+                        import_event.event_type = "import_entity"
                         AND ARRAY_LENGTH(import_event.event_tags) = 1
                         AND DATE(import_event.occurred_at) >= DATE(event_timestamp_checkpoint)
-                        AND DATE(import.checksum_calculated_at) >= DATE(event_timestamp_checkpoint)
                         AND imported_entity_id IS NOT NULL
                     )
                 SELECT
@@ -249,13 +257,13 @@ WHERE
                 FROM
                     ${ctx.self()} AS entity_version
                 /* Join to all imports of this table with matching checksums that took place after this version started to be valid */
-                LEFT JOIN
-                    ${ctx.ref("entity_table_check_import_" + params.eventSourceName)} AS import
+                JOIN
+                    complete_import_with_primary_key AS import
                 ON
                     import.entity_table_name = entity_version.entity_table_name
                     AND entity_version.valid_from < import.checksum_calculated_at
                 /* Join to zero entity versions in each import for this entity version because we only include ones that *are not* in any imports after the valid_from */
-                /* The WHERE imported_entity.imported_entity_id IS NULL below ensures this */
+                /* The HAVING COUNT(DISTINCT imported_entity.imported_entity_id) = 0 below ensures this */
                 LEFT JOIN
                     imported_entity
                 ON
@@ -265,15 +273,15 @@ WHERE
                 WHERE
                     entity_version.valid_to IS NULL
                     AND entity_version.entity_table_name_and_valid_to_partition_number < 1000
-                    AND import.database_checksum = import.bigquery_checksum
-                    AND imported_entity.imported_entity_id IS NULL
                 GROUP BY
                     entity_version.entity_table_name,
                     entity_version.entity_id
+                HAVING COUNT(DISTINCT imported_entity.imported_entity_id) = 0
                 ) AS apparently_deleted_entity
             WHERE
                 entity_version.entity_table_name_and_valid_to_partition_number < 1000
                 AND entity_version.entity_table_name = apparently_deleted_entity.entity_table_name
                 AND entity_version.entity_id = apparently_deleted_entity.id_that_was_apparently_deleted
     `)
+
 }


### PR DESCRIPTION
- Switch reliance on an ID being null in a LEFT JOIN to a CTE of records included in an import to use a HAVING(COUNT DISTINCT ...) = 0. I *think* this fixes the issue, and have tested it for the ID it was reported on (3275) where the mechanism should *not* have fired but did, as well as an ID that looks like the mechanism did fire when it should have.
- Refactor CTEs to have only one dependency on the import checksum table to make it easier to debug this code (e.g. to filter down to just one table), reduce duplication of logic and improve readability
- Switch some LEFT JOINs to JOINs where possible to improve query efficiency
- Switch test data used over to Register and update Register configuration parameters to match production

Row counts look like they match almost perfectly which is a good start!

```SELECT * FROM `rugged-abacus-218110.dataform_dfe_analytics_dataform_testing_SL_dev.entity_table_check_scheduled_register` WHERE checksum_calculated_on = "2025-02-12" ORDER BY entity_table_name```