### PR TITLE
Fix redundant entries issue in pipeline_snapshot table

### DIFF
--- a/includes/pipeline_snapshot.js
+++ b/includes/pipeline_snapshot.js
@@ -80,6 +80,7 @@ module.exports = (version, params) => {
       FROM
         ${targetTable},
         dfe_analytics_configuration_metrics
+      WHERE event_source_name = "${params.eventSourceName}"
       GROUP BY
         all;
       EXCEPTION WHEN ERROR THEN


### PR DESCRIPTION
Fix redundant entries issue in the `pipeline_snapshot.js` where duplicate values are created in the pipeline_snapshot table. A CTE has been added to filter duplicate data and ensure that only the latest data is captured.