### PR TITLE
Exclude web requests with HTTP error 4xx responses from session_details

### DIFF
--- a/includes/session_details.js
+++ b/includes/session_details.js
@@ -98,10 +98,10 @@ WITH
     AND device_category != "bot"
     -- Do not include bot visits
     AND CONTAINS_SUBSTR(response_content_type, "text/html")
-    -- Only web page visits - not redirects (HTTP error 3xx) or page not found errors (HTTP error 4xx)
+    -- Only web page visits
     AND response_status NOT LIKE "3__"
     AND response_status NOT LIKE "4__"
-    -- Do not include redirects 
+    -- Do not include redirects (HTTP error 3xx) or page not found errors (HTTP error 4xx)
     AND occurred_at > event_timestamp_checkpoint
     -- only events that occurred within 24 hours of the latest session start
  ),


### PR DESCRIPTION
Error 4xx is basically variations on 'page not found'. On CPD we're seeing our web analytics data full of views of random pages that don't exist on our service - mostly bots and attempted hacks. These clog up our web analytics reports and make them harder for users to read.

This would keep the error 5xx responses which are still errors, but server errors - and usually indicate a genuine user problem caused by a bug or similar.

**For release notes:** after updating to this release users should run a full refresh on their session_details table and any downstream tables that depend on it to ensure that HTTP error 4xx responses are excluded for past sessions in session_details, not just future ones.