### PR TITLE
Stop stripping referer domain of https:// before detecting whether it is a search engine/social etc.

### DIFF
--- a/includes/session_details.js
+++ b/includes/session_details.js
@@ -16,9 +16,9 @@ module.exports = (params) => {
         ${ctx.when(params.attributionParameters.includes('gbraid'), `WHEN gbraid IS NOT NULL THEN "PPC"`, ``)}
         ${ctx.when(params.attributionParameters.includes('fbclid'), `WHEN fbclid IS NOT NULL THEN "PPC"`, ``)}
         ${ctx.when(params.attributionParameters.includes('utm_medium'), `WHEN REGEXP_CONTAINS(utm_medium, "(?i)(email)") THEN "Email"`, ``)}
-        WHEN REGEXP_CONTAINS(SPLIT(request_referer_domain, "/")[SAFE_OFFSET(2)], "${params.socialRefererDomainRegex}") THEN "Social"
+        WHEN REGEXP_CONTAINS(request_referer_domain, "${params.socialRefererDomainRegex}") THEN "Social"
         ${ctx.when(params.attributionParameters.includes('utm_medium'), `WHEN REGEXP_CONTAINS(utm_medium, "(?i)(social)") THEN "Social"`, ``)}
-        WHEN REGEXP_CONTAINS(SPLIT(request_referer_domain, "/")[SAFE_OFFSET(2)], "${params.searchEngineRefererDomainRegex}") THEN "Organic"
+        WHEN REGEXP_CONTAINS(request_referer_domain, "${params.searchEngineRefererDomainRegex}") THEN "Organic"
         ${ctx.when(params.attributionParameters.includes('utm_medium'), `WHEN REGEXP_CONTAINS(utm_medium, "(?i)(organic)") THEN "Organic"`, ``)}
         WHEN REGEXP_CONTAINS(request_referer_domain, "${params.attributionDomainExclusionRegex}") THEN "Direct or unknown"
         WHEN request_referer_domain IS NOT NULL THEN "Referral"


### PR DESCRIPTION
This was needed when medium was generated in pageview_with_funnels but isn't needed here in session_details, because here we're just using the domain, which has the protocol pre-stripped.

This prevented medium containing Social or Organic.