### PR TITLE
Add dependabot config to open PRs for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - javascript
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - DevOps
+      - dependencies
+      - github_actions


### PR DESCRIPTION
Context
Enable dependabot to open PRs on security updates.

Trello tickets: https://trello.com/c/qXIV068t

Changes proposed in this pull request:
- Open PRs for javascript dependencies
- Open PRs for github action dependencies