### PR TITLE
Add hasTimestamps flag to support Airbyte pipeline for non-Rails services

### DIFF
--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -19,6 +19,7 @@ dfeAnalyticsDataform({
     
     // NEW: Enable Airbyte
     enableAirbyteSource: true,
+    hasTimestamps: true,
     
     airbyteConfig: {
         datasetName: "rtt_airbyte_production",                    

--- a/includes/airbyte_entity_latest.js
+++ b/includes/airbyte_entity_latest.js
@@ -10,6 +10,7 @@ module.exports = (params) => {
     return params.dataSchema.map(tableSchema => {
         const versionTableName = `${tableSchema.entityTableName}_version_${params.eventSourceName}${suffix}`;
         const primaryKey = tableSchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
+        const hasTimestamps = tableSchema.hasTimestamps; 
         
         const fieldAssertionDependencies = params.airbyteEnableAssertions
             ? params.dataSchema.map(schema =>
@@ -34,8 +35,10 @@ module.exports = (params) => {
                     entitytabletype: "latest"
                 },
                 ...((tableSchema.materialisation || 'table') == "table" ? {
-                    partitionBy: "DATE(created_at)"
-                } : {})
+                    partitionBy: hasTimestamps 
+                        ? "DATE(created_at)" 
+                        : "DATE(last_streamed_event_occurred_at)" 
+                    } : {})
             },
             tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'latest'],
             description: "[AIRBYTE] Latest version of " + tableSchema.entityTableName + ". Sourced from the Airbyte version table in the " + params.airbyteConfig.datasetName + " dataset. " + (tableSchema.description || ''),
@@ -45,8 +48,12 @@ module.exports = (params) => {
                     description: `Primary key of the ${tableSchema.entityTableName} entity.`,
                     bigqueryPolicyTags: tableSchema.hidePrimaryKey && params.hiddenPolicyTagLocation ? [params.hiddenPolicyTagLocation] : []
                 },
-                created_at: "Timestamp this entity was first saved in the database.",
-                updated_at: "Timestamp this entity was last updated in the database.",
+                ...(hasTimestamps ? {
+                        created_at: "Timestamp this entity was first saved in the database.",
+                        updated_at: "Timestamp this entity was last updated in the database.",
+                    } : {
+                        created_at: "Always NULL. This entity does not have a created_at column in the source database (non-Rails service).",
+                    }),
             }, ...parameterFunctions.getKeyColumns(tableSchema.keys))
         }).query(ctx => `
 SELECT

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -180,7 +180,7 @@ ${ctx.incremental() ? `
         ) IS NULL AS is_deleted,
       ROW_NUMBER() OVER (
         PARTITION BY live_records.${primaryKey}
-        ORDER BY updated_at DESC, cdc_updated_at DESC
+        ORDER BY ${hasTimestamps ? `updated_at DESC, ` : ``}cdc_updated_at DESC
       ) = 1
         AND (deletions.deleted_at IS NULL OR deletions.deleted_at <= cdc_updated_at) AS is_current,
       ROW_NUMBER() OVER (

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -28,6 +28,7 @@ module.exports = (params) => {
         const tableName = `${entitySchema.entityTableName}_version_${params.eventSourceName}${suffix}`;
         const sourceTable = `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``;
         const primaryKey = entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
+        const hasTimestamps = entitySchema.hasTimestamps;
 
         const fieldAssertionDependencies = params.airbyteEnableAssertions ?
             params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
@@ -39,20 +40,26 @@ module.exports = (params) => {
                 uniqueKey: [primaryKey, "valid_from"],
                 description: `[AIRBYTE] Version history of ${entitySchema.entityTableName} entities. ${entitySchema.description || ''}`,
                 columns: Object.assign({
-                        [primaryKey]: `Primary key of the ${entitySchema.entityTableName} entity.`,
-                        valid_from: "Timestamp from which this version was valid (updated_at from the source).",
-                        valid_to: "Timestamp until which this version was valid. NULL = current.",
-                        is_current: "TRUE if this is the current version.",
-                        is_deleted: "TRUE if this entity is deleted.",
-                        version_number: "Sequential version number (1 = oldest).",
-                        created_at: "Timestamp this entity was first saved in the database.",
-                        updated_at: "Timestamp this entity was last updated in the database.",
-                        cdc_updated_at: "Timestamp of the CDC event captured by Airbyte.",
-                        deleted_at: "Timestamp of the CDC event at which the entity was deleted in the source database. NULL if not deleted.",
-                        _airbyte_raw_id: "Unique identifier assigned by Airbyte to each raw record ingested.",
-                        _airbyte_extracted_at: "Timestamp of the Airbyte extraction"
-                    },
-                    ...(entitySchema.keys ? parameterFunctions.getKeyColumns(entitySchema.keys) : [])
+                    [primaryKey]: `Primary key of the ${entitySchema.entityTableName} entity.`,
+                    valid_from: hasTimestamps
+                        ? "Timestamp from which this version was valid (updated_at from the source database)."
+                        : "Timestamp from which this version was valid (CDC event timestamp from Airbyte, used as a substitute because this entity does not have an updated_at column in the source database).",
+                    valid_to: "Timestamp until which this version was valid. NULL if this is the current version.",
+                    is_current: "TRUE if this is the most recent non-deleted version of the entity.",
+                    is_deleted: "TRUE if this entity has been soft-deleted via a CDC deletion event.",
+                    version_number: "Sequential version number for this entity, starting at 1 (oldest).",
+                    ...(hasTimestamps ? {
+                        created_at: "Timestamp this entity was first saved in the source database.",
+                        updated_at: "Timestamp this entity was last updated in the source database. Also used as valid_from to derive version history.",
+                    } : {
+                        created_at: "Always NULL. This entity does not have a created_at column in the source database (non-Rails service).",
+                    }),
+                    cdc_updated_at: "Timestamp of the CDC change event captured by Airbyte. Derived from _ab_cdc_updated_at. For entities without updated_at, this is also used as valid_from.",
+                    deleted_at: "Timestamp of the CDC deletion event at which this entity was deleted in the source database. NULL if the entity has not been deleted.",
+                    _airbyte_raw_id: "Unique identifier assigned by Airbyte to each raw record ingested from the source.",
+                    _airbyte_extracted_at: "Timestamp when Airbyte extracted this record from the source database.",
+                },
+                ...(entitySchema.keys ? parameterFunctions.getKeyColumns(entitySchema.keys) : [])
                 ),
                 bigquery: {
                     partitionBy: "DATE(valid_to)",
@@ -89,8 +96,7 @@ WITH
       CAST(${primaryKey} AS STRING) AS ${primaryKey},
       * EXCEPT (
           ${primaryKey},
-          created_at,
-          updated_at,
+          ${hasTimestamps ? 'created_at, updated_at,' : ''}
           _airbyte_raw_id,
           _airbyte_meta,
           _airbyte_generation_id,
@@ -99,8 +105,11 @@ WITH
           _ab_cdc_deleted_at
       ),
       TIMESTAMP(LEFT(_ab_cdc_updated_at, 26)) AS cdc_updated_at,
-      TIMESTAMP(created_at) AS created_at,
-      TIMESTAMP(updated_at) AS updated_at,
+      ${hasTimestamps
+        ? `TIMESTAMP(created_at) AS created_at, TIMESTAMP(updated_at) AS updated_at,`
+        : `CAST(NULL AS TIMESTAMP) AS created_at,`
+        /* updated_at omitted entirely; cdc_updated_at takes its role */
+        }
       TIMESTAMP(_ab_cdc_deleted_at) AS deleted_at,
       CAST(_airbyte_raw_id AS STRING) AS _airbyte_raw_id
     FROM ${sourceTable}
@@ -108,7 +117,7 @@ WITH
       ${primaryKey} IS NOT NULL
       AND _airbyte_extracted_at > extracted_at_checkpoint
     QUALIFY ROW_NUMBER() OVER (
-      PARTITION BY CAST(${primaryKey} AS STRING), TIMESTAMP(updated_at)
+      PARTITION BY CAST(${primaryKey} AS STRING), ${hasTimestamps ? `TIMESTAMP(updated_at)` : `cdc_updated_at`}
       ORDER BY _airbyte_extracted_at DESC
     ) = 1
   ),
@@ -131,7 +140,8 @@ ${ctx.incremental() ? `
         SELECT 1
         FROM source_data s
         WHERE s.${primaryKey} = ${ctx.self()}.${primaryKey}
-          AND s.updated_at = ${ctx.self()}.updated_at
+          AND s.${hasTimestamps ? `updated_at` : `cdc_updated_at`} 
+            = ${ctx.self()}.${hasTimestamps ? `updated_at` : `cdc_updated_at`}
       )
   ),
 ` : ``}
@@ -153,12 +163,12 @@ ${ctx.incremental() ? `
   )
     SELECT
       live_records.*,
-      updated_at AS valid_from,
+      ${hasTimestamps ? `updated_at` : `cdc_updated_at`} AS valid_from,
       /* valid_to is either the next version's updated_at, or if no next version exists, the deletion timestamp (if deleted) */
       COALESCE(
-        LEAD(updated_at) OVER (
-          PARTITION BY live_records.${primaryKey}
-          ORDER BY updated_at ASC, cdc_updated_at ASC
+        LEAD(${hasTimestamps ? `updated_at` : `cdc_updated_at`}) OVER (
+            PARTITION BY live_records.${primaryKey}
+            ORDER BY ${hasTimestamps ? `updated_at ASC, ` : ``} cdc_updated_at ASC
         ),
         IF(deletions.deleted_at > cdc_updated_at, deletions.deleted_at, NULL)
       ) AS valid_to,
@@ -166,7 +176,7 @@ ${ctx.incremental() ? `
         AND deletions.deleted_at > updated_at
         AND LEAD(updated_at) OVER (
           PARTITION BY live_records.${primaryKey}
-          ORDER BY updated_at ASC, cdc_updated_at ASC
+          ORDER BY ${hasTimestamps ? `updated_at ASC, ` : ``}cdc_updated_at ASC
         ) IS NULL AS is_deleted,
       ROW_NUMBER() OVER (
         PARTITION BY live_records.${primaryKey}
@@ -175,7 +185,7 @@ ${ctx.incremental() ? `
         AND (deletions.deleted_at IS NULL OR deletions.deleted_at <= cdc_updated_at) AS is_current,
       ROW_NUMBER() OVER (
         PARTITION BY live_records.${primaryKey}
-        ORDER BY updated_at ASC, cdc_updated_at ASC
+        ORDER BY ${hasTimestamps ? `updated_at ASC, ` : ``}cdc_updated_at ASC
       ) AS version_number
     FROM live_records
     LEFT JOIN deletions USING (${primaryKey})

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -173,8 +173,8 @@ ${ctx.incremental() ? `
         IF(deletions.deleted_at > cdc_updated_at, deletions.deleted_at, NULL)
       ) AS valid_to,
       deletions.deleted_at IS NOT NULL
-        AND deletions.deleted_at > updated_at
-        AND LEAD(updated_at) OVER (
+        AND deletions.deleted_at > ${hasTimestamps ? `updated_at` : `cdc_updated_at`} 
+        AND LEAD(${hasTimestamps ? `updated_at` : `cdc_updated_at`}) OVER (
           PARTITION BY live_records.${primaryKey}
           ORDER BY ${hasTimestamps ? `updated_at ASC, ` : ``}cdc_updated_at ASC
         ) IS NULL AS is_deleted,

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -28,7 +28,8 @@ const validTopLevelParameters = ['eventSourceName',
     // Airbyte parameters
     'enableAirbyteSource',
     'airbyteConfig',
-    'airbyteHeartbeat'
+    'airbyteHeartbeat',
+    'hasTimestamps'
 ];
 const validDataSchemaTableParameters = ['entityTableName',
     'description',
@@ -38,7 +39,8 @@ const validDataSchemaTableParameters = ['entityTableName',
     'dataFreshnessDays',
     'dataFreshnessDisableDuringRange',
     'materialisation',
-    'expirationDays'
+    'expirationDays',
+    'hasTimestamps'
 ];
 const validCustomEventSchemaEventParameters = ['eventType',
     'description',
@@ -199,6 +201,10 @@ function validateParams(params) {
             throw new Error("datasetName parameter is required in the airbyteConfig configuration block when enableAirbyteSource is true");
         }
 
+        if (params.hasTimestamps !== undefined && typeof params.hasTimestamps !== 'boolean') {
+    throw new Error(`hasTimestamps must be a boolean value (true or false), not "${params.hasTimestamps}".`);
+}
+
         // Validate dataSchema has required fields for Airbyte
         params.dataSchema.forEach(entity => {
             if (!entity.entityTableName) {
@@ -206,6 +212,9 @@ function validateParams(params) {
             }
             if (!entity.keys) {
                 throw new Error(`Entity '${entity.entityTableName}' must have 'keys' defined for Airbyte processing`);
+            }
+            if (entity.hasTimestamps !== undefined && typeof entity.hasTimestamps !== 'boolean') {
+        throw new Error(`hasTimestamps for entity '${entity.entityTableName}' must be a boolean value (true or false), not "${entity.hasTimestamps}".`);
             }
         });
     }
@@ -219,6 +228,13 @@ function setDefaultSchemaParameters(params) {
         if (!tableSchema.materialisation) {
             tableSchema.materialisation = 'table';
         }
+
+        if (tableSchema.hasTimestamps === undefined) {
+            tableSchema.hasTimestamps = params.hasTimestamps !== undefined
+                ? params.hasTimestamps
+                : true;
+        }
+        
         // Set default value of key level hiddenPolicyTagLocation to match event source level hiddenPolicyTagLocation if not set explicitly and the field is actually hidden
         tableSchema.keys.forEach(key => {
             if (key.hidden && !key.hiddenPolicyTagLocation) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const version = "2.5.0";
+const version = "2.5.1";
 
 const parameterFunctions = require("./includes/parameter_functions");
 
@@ -86,6 +86,7 @@ module.exports = (params) => {
         }], // an array of day or date ranges between which some assertions will be disabled if other parameters are set to disable them. Each range is a hash containing either the integer values fromDay, fromMonth, toDay and toMonth *or* the date values fromDate and toDate. Defaults to an approximation to school holidays each year.
 
         enableAirbyteSource: false, // Master switch for Airbyte processing
+        hasTimestamps: true,       // global default; set to false for non-Rails services without created_at/updated_at
 
         airbyteConfig: {
             datasetName: null, // name of the BigQuery dataset that Airbyte streams data into


### PR DESCRIPTION
## Context

The Airbyte pipeline fails at runtime in BigQuery when installed for non-Rails services (e.g. dotnet) that do not have `created_at` or `updated_at` columns. These columns are a Rails convention and are hard-coded throughout `airbyte_entity_version.js`. 

This PR introduces a hasTimestamps flag so non-Rails services can use the Airbyte pipeline without errors, using `cdc_updated_at` as a semantically correct fallback for versioning.

## What changed?

`index.js`
- Added `hasTimestamps: true` to the global default params block

`includes/parameter_functions.js`
- Added `hasTimestamps` to `validTopLevelParameters` and `validDataSchemaTableParameters`
- Added boolean validation at both global and entity level in `validateParams`
- Added resolution logic in `setDefaultSchemaParameters` - entity level overrides global, global overrides hardcoded default of true

`includes/airbyte_entity_version.js`
- When `hasTimestamps: false`, removes `created_at`/`updated_at` from the query; falls back to `cdc_updated_at` throughout
- Updated column descriptions

`includes/airbyte_entity_latest.js`
- `partitionBy` falls back to DATE(`last_streamed_event_occurred_at`) when `hasTimestamps: false`
- Updated column descriptions

created_at and updated_at marked as optional columns in both schema assertions

## Type of change
- [ ] New model / table / view <!-- Adds a new output object, such as a new table, view, or derived dataset. -->
- [x] Change to existing model / table / view <!-- Changes the structure, logic, grain, fields, joins, filters, or output of an existing model, table, or view. -->
- [x] Bug fix <!-- Corrects behaviour that was producing incorrect, incomplete, duplicated, or unexpected data. -->
- [ ] Performance improvement <!-- Improves runtime, query efficiency, cost, scalability, or reduces unnecessary processing without intentionally changing the output. -->
- [ ] Refactor / cleanup <!-- Improves code structure, readability, maintainability, or removes duplication without intentionally changing the output. -->
- [x] Metadata / documentation <!-- Adds or updates field descriptions, table metadata, README content, comments, tags, or other documentation. -->
- [ ] Test / assertion <!-- Adds or updates tests, assertions, data quality checks, validation logic, or safeguards. -->
- [ ] dfe-analytics-dataform update <!-- Updates shared Dataform package usage, configuration, helper functions, macros, dependencies, or Dataform setup. -->
- [ ] Other: <!-- Use this for changes that do not fit the categories above -->

## Notes for reviewers

- `hasTimestamps` defaults to true so all existing Rails services are completely unaffected — no config changes needed
- The resolution hierarchy is: entity-level `hasTimestamps` → global `hasTimestamps` → hardcoded `true`. This allows mixed services (some entities with timestamps, some without) to be configured at entity level without setting a global flag

## Reviewers Checklist

### Design

- [x] Output structure and grain are appropriate for the use case.
- [x] Logic is implemented at the right layer of the pipeline.
- [x] Reusable logic is not unnecessarily repeated.

### Code quality

- [x] Code is understandable and avoids obvious anti-patterns.
- [x] SQL is as simple as possible without changing the output.

### Metadata and documentation

- [x] Output fields have clear, useful metadata.
- [x] Complex or non-obvious logic is documented.

### Robustness

- [x] Relevant tests, assertions, or safeguards are in place.
- [x] Breaking changes are clearly flagged and versioned appropriately.
- [x] Important assumptions, caveats, or non-obvious behaviours documented
