### PR TITLE
Bugfix: Detecting missing deletion events in Airbyte pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ In addition to step 13 of the setup instructions, the following Airbyte-related 
 - ```tableName``` - name of the Airbyte heartbeat table. Defaults to ```'airbyte_heartbeat'``` if not specified.
 - ```disableFreshnessCheckDuringRange``` - ```true``` or ```false```. If set to ```true```, disables the heartbeat freshness check assertion when today's date falls within one of the date ranges specified in ```assertionDisableDuringDateRanges```. Defaults to ```false``` if not specified.
 
+```airbyteReconciliation``` - optional configuration block to enable reconciliation of CDC deletion events missed during Airbyte outages. When enabled, detects completed Airbyte full-refresh snapshots by their LSN signature, infers which entities were absent from the snapshot, and soft-deletes them in the version table. Disabled by default. Contains the following parameters:
+- ```enabled``` - ```true``` or ```false```. Defaults to ```false```. Set to ```true``` to enable the reconciliation pipeline for all entities in ```dataSchema```.
+- ```minLiveFraction``` - number between 0 and 1. Defaults to ```0.8```. A snapshot must contain at least this fraction of live rows to qualify as a full refresh. Prevents partial syncs from being misclassified as full refreshes.
+- ```maxDeleteFraction``` - number between 0 and 1. Defaults to ```0.2```. The circuit breaker trips if inferred deletions exceed this fraction of live rows, blocking the apply step. Prevents bulk transactions from being misclassified as full refreshes and causing mass deletions.
+- ```minSnapshotAgeMinutes``` - integer number of minutes. Defaults to ```60```. Snapshots more recent than this are ignored as potentially still in-flight (resumable snapshots can span multiple syncs).
+- ```detectionWindowDays``` - integer number of days. Defaults to ```7```. The lookback window used when scanning the Airbyte raw table for full-refresh signatures. Also used as a partition pruning hint to reduce scan cost.
+- ```forceReconcileSnapshotLsn``` - string or null. Defaults to ```null```. One-shot circuit breaker override: set this to the LSN of a known legitimate large deletion, run the pipeline once, then remove it. The circuit breaker will not block apply for that specific snapshot.
 
 ## Updating to a new version
 Users are notified through internal channels when a new version of ```dfe-analytics-dataform``` is released. To update:
@@ -364,6 +371,17 @@ When ```enableAirbyteSource: true``` is set, the following additional tables and
 - An assertion called ```foo_airbyte_global_data_not_fresh``` which fails if the Airbyte heartbeat table has not been updated within the configured ```freshnessHours```.
 
 Both `dfe-analytics` and Airbyte tables coexist in the same Dataform project. Airbyte output tables are distinguished by the ```_airbyte``` suffix (or the value of ```tableSuffix```) and tagged with ```'airbyte'``` in Dataform.
+
+When ```airbyteReconciliation.enabled: true``` is set, the following additional actions are created for each entity ```bar``` with source ```foo```:
+
+- A table called ```bar_airbyte_full_refreshes_foo```, which detects completed Airbyte full-refresh snapshots for the ```bar``` entity by their LSN signature (a full refresh emits the entire table under a single LSN with zero deletes).
+- An incremental table called ```bar_airbyte_reconciliation_deletes_foo```, an append-only audit log of ```bar``` entities inferred as deleted because they were absent from the latest full refresh. This table is ```protected``` — it survives a version table full refresh, so reconciled deletions are not accidentally resurrected.
+- An assertion called ```bar_airbyte_reconciliation_exceeds_safe_delete_volume_foo```, a circuit breaker that blocks the apply step if pending inferred deletions exceed ```airbyteReconciliation.maxDeleteFraction``` of live rows. This prevents bulk transactions that mimic a full-refresh signature from causing mass deletions.
+- An operation called ```bar_airbyte_reconciliation_apply_foo```, which applies the inferred deletions to the version table by closing the last live version of each deleted entity (sets ```valid_to```, ```deleted_at```, ```is_current = FALSE```, ```is_deleted = TRUE```). This step only runs if the circuit breaker assertion passes. The ```bar_latest_foo_airbyte``` table depends on this operation when reconciliation is enabled, so it always reads fully reconciled data.
+
+**On first enable**, ```bar_airbyte_full_refreshes_foo``` will be empty until a full refresh is detected within ```detectionWindowDays```. No deletions will be applied during this window — verify the table is populating before relying on reconciled data.
+
+**If the circuit breaker trips** on a known legitimate large deletion, set ```forceReconcileSnapshotLsn``` to the relevant LSN, run the pipeline once, then remove it.
 
 ## Test framework
 Tests with the jest framework are filed in the `tests` folder

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -16,14 +16,14 @@ dfeAnalyticsDataform({
     hiddenPolicyTagLocation: "projects/rugged-abacus-218110/locations/europe-west2/taxonomies/69524444121704657/policyTags/6523652585511281766",
     expirationDays: false,
     enableMonitoring: false,
-    
+
     // NEW: Enable Airbyte
     enableAirbyteSource: true,
     hasTimestamps: true,
-    
+
     airbyteConfig: {
-        datasetName: "rtt_airbyte_production",                    
-        outputSuffix: "_airbyte",               
+        datasetName: "rtt_airbyte_production",
+        outputSuffix: "_airbyte",
         primaryKeyField: "id"
     },
 
@@ -40,7 +40,7 @@ dfeAnalyticsDataform({
         minSnapshotAgeMinutes: 60,
         detectionWindowDays: 60
     },
-    
+
     dataSchema: [{
             entityTableName: "academic_cycles",
             description: "",
@@ -129,7 +129,7 @@ dfeAnalyticsDataform({
                 description: "Message describing the error in detail."
             }]
         },
-            {
+        {
             entityTableName: "bulk_update_trainee_uploads",
             materialisation: "view",
             description: "This table contains information about the bulk upload update for trainees",
@@ -744,6 +744,16 @@ dfeAnalyticsDataform({
             description: "",
             dataFreshnessDays: 3,
             keys: [{
+                    keyName: "additional_dttp_data",
+                    dataType: "string",
+                    description: "Additional dttp data shown were applicable",
+                    hidden: true
+                }, {
+                    keyName: "additional_ethnic_background",
+                    dataType: "string",
+                    description: "Additional ethnicity detail recorded in Register",
+                    hidden: true
+                }, {
                     keyName: "apply_application_id",
                     dataType: "string",
                     description: "Foreign key to apply_applications identifier register_apply_applications .id",
@@ -878,6 +888,16 @@ dfeAnalyticsDataform({
                     description: "",
                     foreignKeyTable: "academic_cycles"
                 }, {
+                    keyName: "ethnic_background",
+                    dataType: "string",
+                    description: "Primary ethnicity category selected by the trainee",
+                    hidden: true
+                }, {
+                    keyName: "ethnic_group",
+                    dataType: "string",
+                    description: "Broad demographic ethnic classification category specified by the trainee",
+                    hidden: true
+                }, {
                     keyName: "first_names",
                     dataType: "string",
                     description: "First name of the trainee",
@@ -916,8 +936,12 @@ dfeAnalyticsDataform({
                     dataType: "string",
                     description: "Last name of the trainee",
                     hidden: true
-                },
-                {
+                }, {
+                    keyName: "middle_names",
+                    dataType: "string",
+                    description: "Middle name(s) of the trainee",
+                    hidden: true
+                }, {
                     keyName: "training_partner_id",
                     pastKeyNames: ["lead_partner_id"],
                     dataType: "string",
@@ -950,6 +974,11 @@ dfeAnalyticsDataform({
                     description: "Registers unique provider identifier. Not used by other services.",
                     foreignKeyTable: "providers"
                 }, {
+                    keyName: "provider_trainee_id",
+                    dataType: "string",
+                    description: "Providers unique trainee identifier. Not used by other services.",
+                    hidden: true
+                }, {
                     keyName: "recommended_for_award_at",
                     dataType: "timestamp",
                     description: ""
@@ -974,6 +1003,11 @@ dfeAnalyticsDataform({
                     dataType: "string",
                     description: "",
                     foreignKeyTable: "academic_cycles"
+                }, {
+                    keyName: "searchable",
+                    dataType: "string",
+                    description: "Weighted full text search tokens used to make the trainee record searchable",
+                    hidden: true
                 }, {
                     keyName: "sex",
                     dataType: "string",
@@ -1176,6 +1210,29 @@ dfeAnalyticsDataform({
                 dataType: "string",
                 description: "",
                 foreignKeyTable: "users"
+            }]
+        },
+        {
+            entityTableName: "feedback_items",
+            description: "Stores responses from the Register integrated feedback form",
+            keys: [{
+                keyName: "satisfaction_level",
+                dataType: "string",
+                description: "User satisfaction rating from the feedback form",
+            }, {
+                keyName: "improvement_suggestion",
+                dataType: "string",
+                description: "Free text comments where users describe issues, suggestions, or ideas for improving Register."
+            }, {
+                keyName: "name",
+                dataType: "string",
+                description: "The respondent’s name, collected for internal follow up where needed.",
+                hidden: true
+            }, {
+                keyName: "email",
+                dataType: "string",
+                description: "The respondent’s email, collected for internal follow up where needed.",
+                hidden: true
             }]
         }
     ],

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -36,7 +36,7 @@ dfeAnalyticsDataform({
     airbyteReconciliation: {
         enabled: true,
         minLiveFraction: 0.8,
-        maxDeleteFraction: 0.5,
+        maxDeleteFraction: 0.2,
         minSnapshotAgeMinutes: 60,
         detectionWindowDays: 60
     },

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -32,6 +32,14 @@ dfeAnalyticsDataform({
         freshnessHours: 12,
         tableName: 'airbyte_heartbeat'
     },
+
+    airbyteReconciliation: {
+                enabled: true,
+                minLiveFraction: 0.8,
+                maxDeleteFraction: 0.5,
+                minSnapshotAgeMinutes: 60,
+                detectionWindowDays: 60
+    },
     
     dataSchema: [{
             entityTableName: "academic_cycles",

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -24,7 +24,7 @@ dfeAnalyticsDataform({
     airbyteConfig: {
         datasetName: "rtt_airbyte_production",
         tableSuffix: "_airbyte",
-        PrimaryKeyField: "id"
+        primaryKeyField: "id"
     },
 
     airbyteHeartbeat: {
@@ -747,7 +747,6 @@ dfeAnalyticsDataform({
                     keyName: "additional_dttp_data",
                     dataType: "string",
                     description: "Additional dttp data shown where applicable",
-
                     hidden: true
                 }, {
                     keyName: "additional_ethnic_background",

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -34,11 +34,11 @@ dfeAnalyticsDataform({
     },
 
     airbyteReconciliation: {
-                enabled: true,
-                minLiveFraction: 0.8,
-                maxDeleteFraction: 0.5,
-                minSnapshotAgeMinutes: 60,
-                detectionWindowDays: 60
+        enabled: true,
+        minLiveFraction: 0.8,
+        maxDeleteFraction: 0.5,
+        minSnapshotAgeMinutes: 60,
+        detectionWindowDays: 60
     },
     
     dataSchema: [{

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -746,7 +746,7 @@ dfeAnalyticsDataform({
             keys: [{
                     keyName: "additional_dttp_data",
                     dataType: "string",
-                    description: "Additional dttp data shown were applicable",
+                    description: "Additional dttp data shown where applicable",
                     hidden: true
                 }, {
                     keyName: "additional_ethnic_background",

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -24,7 +24,7 @@ dfeAnalyticsDataform({
     airbyteConfig: {
         datasetName: "rtt_airbyte_production",
         tableSuffix: "_airbyte",
-        defaultPrimaryKeyField: "id"
+        PrimaryKeyField: "id"
     },
 
     airbyteHeartbeat: {

--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -23,8 +23,8 @@ dfeAnalyticsDataform({
 
     airbyteConfig: {
         datasetName: "rtt_airbyte_production",
-        outputSuffix: "_airbyte",
-        primaryKeyField: "id"
+        tableSuffix: "_airbyte",
+        defaultPrimaryKeyField: "id"
     },
 
     airbyteHeartbeat: {
@@ -746,7 +746,8 @@ dfeAnalyticsDataform({
             keys: [{
                     keyName: "additional_dttp_data",
                     dataType: "string",
-                    description: "Additional dttp data shown where applicable",
+                    description: "Additional dttp data shown where applicable",
+
                     hidden: true
                 }, {
                     keyName: "additional_ethnic_background",

--- a/includes/airbyte_entity_latest.js
+++ b/includes/airbyte_entity_latest.js
@@ -1,6 +1,7 @@
 /* Generates {entity}_latest_{source}{suffix} tables from Airbyte raw data; Contains the most recent version of each entity. */
 
 const parameterFunctions = require("./parameter_functions");
+const airbyteReconciliation = require("./airbyte_reconciliation");
 
 module.exports = (params) => {
     if (!params.enableAirbyteSource) return null;
@@ -20,7 +21,12 @@ module.exports = (params) => {
 
         publish(tableSchema.entityTableName + "_latest_" + params.eventSourceName + suffix, {
             ...params.defaultConfig,
-            dependencies: fieldAssertionDependencies, 
+            dependencies: [
+                ...fieldAssertionDependencies,
+                ...(params.airbyteReconciliation.enabled
+                    ? [airbyteReconciliation.reconciliationNames(params, tableSchema).applyOperationName]
+                    : [])
+            ],
             type: tableSchema.materialisation || 'table',
             ...((tableSchema.materialisation || 'table') == "table" ? {
                 assertions: {

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -46,7 +46,7 @@ module.exports = (params) => {
                             "Timestamp from which this version was valid (CDC event timestamp from Airbyte, used as a substitute because this entity does not have an updated_at column in the source database).",
                         valid_to: "Timestamp until which this version was valid. NULL if this is the current version.",
                         is_current: "TRUE if this is the most recent non-deleted version of the entity.",
-                        is_deleted: "TRUE if this entity has been soft-deleted via a CDC deletion event.",
+                        is_deleted: "TRUE if this entity has been soft-deleted via a CDC deletion event or Airbyte full-refresh reconciliation.",
                         version_number: "Sequential version number for this entity, starting at 1 (oldest).",
                         ...(hasTimestamps ? {
                             created_at: "Timestamp this entity was first saved in the source database.",

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -18,7 +18,6 @@
 
 const data_functions = require("./data_functions");
 const parameterFunctions = require("./parameter_functions");
-const airbyteReconciliation = require("./airbyte_reconciliation");
 
 module.exports = (params) => {
     if (!params.enableAirbyteSource) return null;
@@ -30,9 +29,6 @@ module.exports = (params) => {
         const sourceTable = `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``;
         const primaryKey = entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
         const hasTimestamps = entitySchema.hasTimestamps;
-        const reconciliationNames = params.airbyteReconciliation.enabled
-          ? airbyteReconciliation.reconciliationNames(params, entitySchema)
-          : null;
 
         const fieldAssertionDependencies = params.airbyteEnableAssertions ?
             params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
@@ -40,9 +36,7 @@ module.exports = (params) => {
         return publish(tableName, {
                 type: "incremental",
                 protected: false,
-                dependencies: fieldAssertionDependencies.concat(
-                              reconciliationNames ? [reconciliationNames.volumeGuardAssertionName] : []
-                            ),
+                dependencies: fieldAssertionDependencies,
                 uniqueKey: [primaryKey, "valid_from"],
                 description: `[AIRBYTE] Version history of ${entitySchema.entityTableName} entities. ${entitySchema.description || ''}`,
                 columns: Object.assign({
@@ -153,22 +147,14 @@ ${ctx.incremental() ? `
 ` : ``}
 
   deletions AS (
-  /* Filter out deletion rows, they signal that the previous version ended. Keep them in a separate CTE. */
+    /* Filter out deletion rows, they signal that the previous version ended. Keep them in a separate CTE. */
     SELECT
-      ${primaryKey},
-      MAX(deleted_at) AS deleted_at
-    FROM (
-      SELECT ${primaryKey}, deleted_at
-      FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
-      WHERE deleted_at IS NOT NULL
-      ${params.airbyteReconciliation.enabled ? `
-      UNION ALL
-      /* Synthetic deletions inferred from Airbyte full refresh reconciliation */
-      SELECT ${primaryKey}, deleted_at_assumed AS deleted_at
-      FROM ${ctx.ref(reconciliationNames.reconciliationDeletesTableName)}` : ``}
-    )
+    ${primaryKey},
+    MAX(deleted_at) AS deleted_at
+    FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
+    WHERE deleted_at IS NOT NULL
     GROUP BY ${primaryKey}
-  ),
+    ),
 
   live_records AS (
     SELECT *

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -165,7 +165,7 @@ ${ctx.incremental() ? `
       UNION ALL
       /* Synthetic deletions inferred from Airbyte full refresh reconciliation */
       SELECT ${primaryKey}, deleted_at_assumed AS deleted_at
-      FROM ${ctx.ref(reconciliationDeletesTableName)}` : ``}
+      FROM ${ctx.ref(reconciliationNames.reconciliationDeletesTableName)}` : ``}
     )
     GROUP BY ${primaryKey}
   ),

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -18,6 +18,7 @@
 
 const data_functions = require("./data_functions");
 const parameterFunctions = require("./parameter_functions");
+const airbyteReconciliation = require("./airbyte_reconciliation");
 
 module.exports = (params) => {
     if (!params.enableAirbyteSource) return null;
@@ -29,6 +30,9 @@ module.exports = (params) => {
         const sourceTable = `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``;
         const primaryKey = entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
         const hasTimestamps = entitySchema.hasTimestamps;
+        const reconciliationNames = params.airbyteReconciliation.enabled
+          ? airbyteReconciliation.reconciliationNames(params, entitySchema)
+          : null;
 
         const fieldAssertionDependencies = params.airbyteEnableAssertions ?
             params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
@@ -36,30 +40,32 @@ module.exports = (params) => {
         return publish(tableName, {
                 type: "incremental",
                 protected: false,
-                dependencies: fieldAssertionDependencies,
+                dependencies: fieldAssertionDependencies.concat(
+                              reconciliationNames ? [reconciliationNames.volumeGuardAssertionName] : []
+                            ),
                 uniqueKey: [primaryKey, "valid_from"],
                 description: `[AIRBYTE] Version history of ${entitySchema.entityTableName} entities. ${entitySchema.description || ''}`,
                 columns: Object.assign({
-                    [primaryKey]: `Primary key of the ${entitySchema.entityTableName} entity.`,
-                    valid_from: hasTimestamps
-                        ? "Timestamp from which this version was valid (updated_at from the source database)."
-                        : "Timestamp from which this version was valid (CDC event timestamp from Airbyte, used as a substitute because this entity does not have an updated_at column in the source database).",
-                    valid_to: "Timestamp until which this version was valid. NULL if this is the current version.",
-                    is_current: "TRUE if this is the most recent non-deleted version of the entity.",
-                    is_deleted: "TRUE if this entity has been soft-deleted via a CDC deletion event.",
-                    version_number: "Sequential version number for this entity, starting at 1 (oldest).",
-                    ...(hasTimestamps ? {
-                        created_at: "Timestamp this entity was first saved in the source database.",
-                        updated_at: "Timestamp this entity was last updated in the source database. Also used as valid_from to derive version history.",
-                    } : {
-                        created_at: "Always NULL. This entity does not have a created_at column in the source database (non-Rails service).",
-                    }),
-                    cdc_updated_at: "Timestamp of the CDC change event captured by Airbyte. Derived from _ab_cdc_updated_at. For entities without updated_at, this is also used as valid_from.",
-                    deleted_at: "Timestamp of the CDC deletion event at which this entity was deleted in the source database. NULL if the entity has not been deleted.",
-                    _airbyte_raw_id: "Unique identifier assigned by Airbyte to each raw record ingested from the source.",
-                    _airbyte_extracted_at: "Timestamp when Airbyte extracted this record from the source database.",
-                },
-                ...(entitySchema.keys ? parameterFunctions.getKeyColumns(entitySchema.keys) : [])
+                        [primaryKey]: `Primary key of the ${entitySchema.entityTableName} entity.`,
+                        valid_from: hasTimestamps ?
+                            "Timestamp from which this version was valid (updated_at from the source database)." :
+                            "Timestamp from which this version was valid (CDC event timestamp from Airbyte, used as a substitute because this entity does not have an updated_at column in the source database).",
+                        valid_to: "Timestamp until which this version was valid. NULL if this is the current version.",
+                        is_current: "TRUE if this is the most recent non-deleted version of the entity.",
+                        is_deleted: "TRUE if this entity has been soft-deleted via a CDC deletion event.",
+                        version_number: "Sequential version number for this entity, starting at 1 (oldest).",
+                        ...(hasTimestamps ? {
+                            created_at: "Timestamp this entity was first saved in the source database.",
+                            updated_at: "Timestamp this entity was last updated in the source database. Also used as valid_from to derive version history.",
+                        } : {
+                            created_at: "Always NULL. This entity does not have a created_at column in the source database (non-Rails service).",
+                        }),
+                        cdc_updated_at: "Timestamp of the CDC change event captured by Airbyte. Derived from _ab_cdc_updated_at. For entities without updated_at, this is also used as valid_from.",
+                        deleted_at: "Timestamp of the CDC deletion event at which this entity was deleted in the source database. NULL if the entity has not been deleted.",
+                        _airbyte_raw_id: "Unique identifier assigned by Airbyte to each raw record ingested from the source.",
+                        _airbyte_extracted_at: "Timestamp when Airbyte extracted this record from the source database.",
+                    },
+                    ...(entitySchema.keys ? parameterFunctions.getKeyColumns(entitySchema.keys) : [])
                 ),
                 bigquery: {
                     partitionBy: "DATE(valid_to)",
@@ -151,8 +157,16 @@ ${ctx.incremental() ? `
     SELECT
       ${primaryKey},
       MAX(deleted_at) AS deleted_at
-    FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
-    WHERE deleted_at IS NOT NULL
+    FROM (
+      SELECT ${primaryKey}, deleted_at
+      FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
+      WHERE deleted_at IS NOT NULL
+      ${params.airbyteReconciliation.enabled ? `
+      UNION ALL
+      /* Synthetic deletions inferred from Airbyte full refresh reconciliation */
+      SELECT ${primaryKey}, deleted_at_assumed AS deleted_at
+      FROM ${ctx.ref(reconciliationDeletesTableName)}` : ``}
+    )
     GROUP BY ${primaryKey}
   ),
 
@@ -192,7 +206,7 @@ ${ctx.incremental() ? `
 
 
 `)
-      .postOps(ctx => `
+            .postOps(ctx => `
       ${data_functions.setKeyConstraints(ctx, dataform, {
         primaryKey: primaryKey + ", valid_from"
       })}

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -6,7 +6,7 @@
   - {entity}_airbyte_reconciliation_exceeds_safe_delete_volume_{source} (assertion)
   - {entity}_airbyte_reconciliation_apply_{source}                 (operation: UPDATE)
 
-  The apply operation folds inferred deletions into the version table the same way the builder folds observed CDC deletions: 
+  The apply operation incorporates inferred deletions into the version table the same way the builder incorporates observed CDC deletions: 
   by closing the last live version (valid_to / is_current / is_deleted / deleted_at). No INSERT needed.
 
 */
@@ -177,7 +177,7 @@ WHERE
   SAFE_DIVIDE(pending.pending_delete_count, live.live_row_count) > ${maxDeleteFraction}${overrideClause}`;
 }
 
-/* Step 4: apply. Folds inferred deletions into the version table exactly like observed CDC deletions: close the last live version. 
+/* Step 4: apply. Incorporates inferred deletions into the version table exactly like observed CDC deletions: close the last live version. 
    Idempotent: valid_to IS NULL excludes already-applied rows; a real CDC delete that beat us to the same PK in the same run also drops out. 
    The ordering guard protects rows first seen during/after the snapshot. */
 function applyReconciliationQuery({ versionTable, deletesTable, primaryKeyField }) {

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -1,21 +1,14 @@
 /* Generates full-refresh reconciliation tables for Airbyte CDC entities. 
 
    For each entity in dataSchema, when params.airbyteReconciliation.enabled:
-    - {entity}_airbyte_full_refreshes_{source}            (table)
-        Completed Airbyte full-refresh snapshots, detected by LSN signature:
-        a full refresh emits the entire table under a single _ab_cdc_lsn with
-        zero deletes.
-    - {entity}_airbyte_reconciliation_deletes_{source}    (incremental, protected)
-        Append-only log of entities inferred deleted because they were absent
-        from the latest full refresh. Consumed by the deletions CTE in
-        airbyte_entity_version.js, and the permanent audit trail. protected:
-        a version-table full refresh must REPRODUCE reconciled deletions, not
-        resurrect ghost rows.
-    - {entity}_airbyte_reconciliation_exceeds_safe_delete_volume_{source} (assertion)
-        Circuit breaker: fails when pending inferred deletions exceed
-        maxDeleteFraction of live rows (the signature of a bulk transaction
-        misclassified as a full refresh). The version table depends on this
-        assertion, so a trip blocks application.
+  - {entity}_airbyte_full_refreshes_{source}                       (table)
+  - {entity}_airbyte_reconciliation_deletes_{source}               (incremental, protected)
+  - {entity}_airbyte_reconciliation_exceeds_safe_delete_volume_{source} (assertion)
+  - {entity}_airbyte_reconciliation_apply_{source}                 (operation: UPDATE)
+
+  The apply operation folds inferred deletions into the version table the same way the builder folds observed CDC deletions: 
+  by closing the last live version (valid_to / is_current / is_deleted / deleted_at). No INSERT needed.
+
 */
 
 /* Shared naming/reference helper */

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -218,7 +218,6 @@ module.exports = (params) => {
       names.sourceTable,
       ctx.ref(names.fullRefreshesTableName),
       ctx.resolve(names.versionTableName),
-      ctx.resolve(names.latestTableName),
       names.primaryKey,
       ctx.incremental() ? ctx.self() : null
     ));
@@ -228,6 +227,7 @@ module.exports = (params) => {
       description: `[AIRBYTE] Blocks the ${entitySchema.entityTableName} version table if pending inferred deletions exceed airbyteReconciliation.maxDeleteFraction of live rows, which may indicate a bulk transaction misclassified as a full refresh.`
     }).query(ctx => volumeGuardQuery(
       ctx.ref(names.reconciliationDeletesTableName),
+      ctx.resolve(names.versionTableName),
       ctx.resolve(names.latestTableName),
       names.primaryKey,
       params.airbyteReconciliation.maxDeleteFraction,

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -1,0 +1,242 @@
+/* Generates full-refresh reconciliation tables for Airbyte CDC entities. 
+
+   For each entity in dataSchema, when params.airbyteReconciliation.enabled:
+    - {entity}_airbyte_full_refreshes_{source}            (table)
+        Completed Airbyte full-refresh snapshots, detected by LSN signature:
+        a full refresh emits the entire table under a single _ab_cdc_lsn with
+        zero deletes.
+    - {entity}_airbyte_reconciliation_deletes_{source}    (incremental, protected)
+        Append-only log of entities inferred deleted because they were absent
+        from the latest full refresh. Consumed by the deletions CTE in
+        airbyte_entity_version.js, and the permanent audit trail. protected:
+        a version-table full refresh must REPRODUCE reconciled deletions, not
+        resurrect ghost rows.
+    - {entity}_airbyte_reconciliation_exceeds_safe_delete_volume_{source} (assertion)
+        Circuit breaker: fails when pending inferred deletions exceed
+        maxDeleteFraction of live rows (the signature of a bulk transaction
+        misclassified as a full refresh). The version table depends on this
+        assertion, so a trip blocks application.
+*/
+
+/* Shared naming/reference helper */
+function reconciliationNames(params, entitySchema) {
+  const suffix = params.airbyteConfig.tableSuffix || '_airbyte';
+  return {
+    primaryKey: entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id',
+    sourceTable: `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``,
+    versionTableName: `${entitySchema.entityTableName}_version_${params.eventSourceName}${suffix}`,
+    fullRefreshesTableName: `${entitySchema.entityTableName}_airbyte_full_refreshes_${params.eventSourceName}`,
+    reconciliationDeletesTableName: `${entitySchema.entityTableName}_airbyte_reconciliation_deletes_${params.eventSourceName}`,
+    volumeGuardAssertionName: `${entitySchema.entityTableName}_airbyte_reconciliation_exceeds_safe_delete_volume_${params.eventSourceName}`,
+  };
+}
+
+/* Step 1: Detects completed Airbyte full-refresh snapshots for one entity using the LSN signature.
+   A full refresh emits the entire table under a single _ab_cdc_lsn with zero deletes. 
+   A single bulk transaction can mimic this, which is why application is gated by the volume guard assertion. 
+*/
+function fullRefreshDetectionQuery(
+    airbyteSourceTable,
+    latestTable,
+    minLiveFraction,
+    minSnapshotAgeMinutes,
+    detectionWindowDays
+) {
+    return `WITH live AS (
+  SELECT
+    COUNT(*) AS live_row_count
+  FROM
+    ${latestTable}
+),
+lsn_stats AS (
+  SELECT
+    _ab_cdc_lsn AS lsn,
+    COUNT(*) AS row_count,
+    COUNTIF(_ab_cdc_deleted_at IS NOT NULL) AS delete_count,
+    COUNT(DISTINCT CAST(JSON_VALUE(_airbyte_meta, '$.sync_id') AS INT64)) AS sync_count,
+    MIN(_airbyte_extracted_at) AS snapshot_started_at,
+    MAX(_airbyte_extracted_at) AS snapshot_finished_at
+  FROM
+    ${airbyteSourceTable}
+  WHERE
+    _airbyte_extracted_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL ${detectionWindowDays} DAY)
+  GROUP BY
+    lsn
+)
+SELECT
+  lsn_stats.lsn,
+  lsn_stats.row_count,
+  lsn_stats.sync_count,
+  lsn_stats.snapshot_started_at,
+  lsn_stats.snapshot_finished_at,
+  live.live_row_count,
+  SAFE_DIVIDE(lsn_stats.row_count, live.live_row_count) AS fraction_of_live
+FROM
+  lsn_stats
+CROSS JOIN
+  live
+WHERE
+  lsn_stats.delete_count = 0
+  AND lsn_stats.row_count >= ${minLiveFraction} * live.live_row_count
+  /* in-flight guard: resumable snapshots can span multiple syncs */
+  AND lsn_stats.snapshot_finished_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL ${minSnapshotAgeMinutes} MINUTE)`;
+}
+
+/* Step 2: Append-only log of inferred deletions. 
+   selfTable is non-null on incremental runs and prevents re-logging PKs already recorded for the same snapshot.
+*/
+function reconciliationDeletesQuery(
+  sourceTable,               // FQN of the raw Airbyte source table
+  detectionTable,            // resolved name of the detection table
+  versionTable,              // resolved name of the entity version table
+  primaryKeyField,           // e.g. 'id'
+  selfTable                  // resolved self name on incremental runs, else null
+) {
+  const incrementalGuard = selfTable
+    ? `\n  AND NOT EXISTS (
+    SELECT 1
+    FROM ${selfTable} AS log
+    WHERE log.${primaryKeyField} = version.${primaryKeyField}
+      AND log.snapshot_lsn = latest_snapshot.lsn
+  )`
+    : '';
+  return `WITH latest_snapshot AS (
+  SELECT
+    lsn,
+    snapshot_started_at,
+    snapshot_finished_at
+  FROM
+    ${detectionTable}
+  ORDER BY
+    snapshot_finished_at DESC
+  LIMIT 1
+),
+snapshot_pks AS (
+  SELECT DISTINCT
+    CAST(airbyte_source.${primaryKeyField} AS STRING) AS pk
+  FROM
+    ${sourceTable} AS airbyte_source
+  INNER JOIN
+    latest_snapshot
+  ON
+    airbyte_source._ab_cdc_lsn = latest_snapshot.lsn
+)
+SELECT
+  version.${primaryKeyField} AS ${primaryKeyField},
+  latest_snapshot.lsn AS snapshot_lsn,
+  latest_snapshot.snapshot_started_at,
+  latest_snapshot.snapshot_finished_at AS deleted_at_assumed,
+  CURRENT_TIMESTAMP() AS detected_at
+FROM
+  ${versionTable} AS version
+CROSS JOIN
+  latest_snapshot
+LEFT JOIN
+  snapshot_pks
+ON
+  snapshot_pks.pk = version.${primaryKeyField}
+WHERE
+  version.valid_to IS NULL
+  AND snapshot_pks.pk IS NULL
+  /* ordering guard: never flag rows first seen during or after the snapshot */
+  AND version.valid_from < latest_snapshot.snapshot_started_at${incrementalGuard}`;
+}
+
+/* Step 3: Circuit breaker assertion. 
+   Returns rows (fails) when the pending reconciliation would delete more than maxDeleteFraction of live rows - the signature of a bulk transaction misclassified as a full refresh.
+   forceReconcileSnapshotLsn provides a deliberate one-shot override. 
+*/
+function volumeGuardQuery(
+    deletesTable,
+    versionTable,
+    primaryKeyField,
+    maxDeleteFraction,
+    forceReconcileSnapshotLsn
+) {
+  const overrideClause = forceReconcileSnapshotLsn
+    ? `\n  AND pending.snapshot_lsn != ${forceReconcileSnapshotLsn} /* one-shot override set in airbyteReconciliation */`
+    : '';
+  return `WITH live AS (
+  SELECT
+    COUNT(*) AS live_row_count
+  FROM
+    ${versionTable}
+  WHERE
+    valid_to IS NULL
+),
+pending AS (
+  SELECT
+    COUNT(*) AS pending_delete_count,
+    ANY_VALUE(log.snapshot_lsn) AS snapshot_lsn
+  FROM
+    ${deletesTable} AS log
+  INNER JOIN
+    ${versionTable} AS version
+  ON
+    version.${primaryKeyField} = log.${primaryKeyField}
+    AND version.valid_to IS NULL
+)
+SELECT
+  pending.snapshot_lsn,
+  pending.pending_delete_count,
+  live.live_row_count,
+  SAFE_DIVIDE(pending.pending_delete_count, live.live_row_count) AS delete_fraction
+FROM
+  pending
+CROSS JOIN
+  live
+WHERE
+  SAFE_DIVIDE(pending.pending_delete_count, live.live_row_count) > ${maxDeleteFraction}${overrideClause}`;
+}
+
+/* Publish the functions above */
+module.exports = (params) => {
+  if (!params.enableAirbyteSource || !params.airbyteReconciliation.enabled) return null;
+
+  return params.dataSchema.map(entitySchema => {
+    const names = reconciliationNames(params, entitySchema);
+
+    publish(names.fullRefreshesTableName, {
+      type: "table",
+      tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
+      description: `[AIRBYTE] Full refresh snapshots of ${entitySchema.entityTableName} detected by LSN signature, used to reconcile deletions missed by CDC.`
+    }).query(ctx => fullRefreshDetectionQuery(
+      names.sourceTable,
+      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      params.airbyteReconciliation.minLiveFraction,
+      params.airbyteReconciliation.minSnapshotAgeMinutes,
+      params.airbyteReconciliation.detectionWindowDays
+    ));
+
+    publish(names.reconciliationDeletesTableName, {
+      type: "incremental",
+      protected: true, // survives full refreshes: this log is what stops version-table rebuilds resurrecting reconciled ghost rows
+      uniqueKey: [names.primaryKey, "snapshot_lsn"],
+      tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
+      description: `[AIRBYTE] Append-only log of ${entitySchema.entityTableName} entities inferred deleted because they were absent from an Airbyte full refresh. Consumed by the deletions logic in the version table; also the permanent audit trail of reconciled deletions. deleted_at_assumed is the snapshot extraction time, unlike CDC deletion timestamps which are source-database time.`
+    }).query(ctx => reconciliationDeletesQuery(
+      names.sourceTable,
+      ctx.ref(names.fullRefreshesTableName),
+      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      names.primaryKey,
+      ctx.incremental() ? ctx.self() : null
+    ));
+
+    return assert(names.volumeGuardAssertionName, {
+      tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
+      description: `[AIRBYTE] Blocks the ${entitySchema.entityTableName} version table if pending inferred deletions exceed airbyteReconciliation.maxDeleteFraction of live rows, which may indicate a bulk transaction misclassified as a full refresh.`
+    }).query(ctx => volumeGuardQuery(
+      ctx.ref(names.reconciliationDeletesTableName),
+      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      names.primaryKey,
+      params.airbyteReconciliation.maxDeleteFraction,
+      params.airbyteReconciliation.forceReconcileSnapshotLsn
+    ));
+  });
+};
+
+// Named properties for airbyte_entity_version.js and Jest:
+module.exports.reconciliationNames = reconciliationNames;
+module.exports.fullRefreshDetectionQuery = fullRefreshDetectionQuery;
+module.exports.reconciliationDeletesQuery = reconciliationDeletesQuery;
+module.exports.volumeGuardQuery = volumeGuardQuery;

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -106,7 +106,8 @@ snapshot_pks AS (
     latest_snapshot
   ON
     airbyte_source._ab_cdc_lsn = latest_snapshot.lsn
-    AND airbyte_source._airbyte_extracted_at >= latest_snapshot.snapshot_started_at 
+    AND airbyte_source._airbyte_extracted_at 
+    BETWEEN latest_snapshot.snapshot_started_at 
         AND latest_snapshot.snapshot_finished_at
 )
 SELECT

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -25,10 +25,10 @@ function reconciliationNames(params, entitySchema) {
     primaryKey: entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id',
     sourceTable: `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``,
     versionTableName: `${entitySchema.entityTableName}_version_${params.eventSourceName}${suffix}`,
-    latestTableName: `${entitySchema.entityTableName}_latest_${params.eventSourceName}${suffix}`,
     fullRefreshesTableName: `${entitySchema.entityTableName}_airbyte_full_refreshes_${params.eventSourceName}`,
     reconciliationDeletesTableName: `${entitySchema.entityTableName}_airbyte_reconciliation_deletes_${params.eventSourceName}`,
     volumeGuardAssertionName: `${entitySchema.entityTableName}_airbyte_reconciliation_exceeds_safe_delete_volume_${params.eventSourceName}`,
+    applyOperationName: `${entitySchema.entityTableName}_airbyte_reconciliation_apply_${params.eventSourceName}`,
   };
 }
 
@@ -36,18 +36,15 @@ function reconciliationNames(params, entitySchema) {
    A full refresh emits the entire table under a single _ab_cdc_lsn with zero deletes. 
    A single bulk transaction can mimic this, which is why application is gated by the volume guard assertion. 
 */
-function fullRefreshDetectionQuery(
-    airbyteSourceTable,
-    latestTable,
-    minLiveFraction,
-    minSnapshotAgeMinutes,
-    detectionWindowDays
-) {
-    return `WITH live AS (
+function fullRefreshDetectionQuery({ sourceTable, versionTable, minLiveFraction, minSnapshotAgeMinutes, detectionWindowDays }) {
+  return `WITH live AS (
+  /* Live rows are exactly valid_to IS NULL in this builder (deleted entities have valid_to set) */
   SELECT
     COUNT(*) AS live_row_count
   FROM
-    ${latestTable}
+    ${versionTable}
+  WHERE
+    valid_to IS NULL
 ),
 lsn_stats AS (
   SELECT
@@ -58,7 +55,7 @@ lsn_stats AS (
     MIN(_airbyte_extracted_at) AS snapshot_started_at,
     MAX(_airbyte_extracted_at) AS snapshot_finished_at
   FROM
-    ${airbyteSourceTable}
+    ${sourceTable}
   WHERE
     _airbyte_extracted_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL ${detectionWindowDays} DAY)
   GROUP BY
@@ -86,15 +83,10 @@ WHERE
 /* Step 2: Append-only log of inferred deletions. 
    selfTable is non-null on incremental runs and prevents re-logging PKs already recorded for the same snapshot.
 */
-function reconciliationDeletesQuery(
-  sourceTable,               // FQN of the raw Airbyte source table
-  detectionTable,            // resolved name of the detection table
-  versionTable,              // resolved name of the entity version table
-  primaryKeyField,           // e.g. 'id'
-  selfTable                  // resolved self name on incremental runs, else null
-) {
+function reconciliationDeletesQuery({sourceTable, detectionTable, versionTable, primaryKeyField, selfTable}) {
   const incrementalGuard = selfTable
-    ? `\n  AND NOT EXISTS (
+    ? `
+  AND NOT EXISTS (
     SELECT 1
     FROM ${selfTable} AS log
     WHERE log.${primaryKeyField} = version.${primaryKeyField}
@@ -147,22 +139,18 @@ WHERE
    Returns rows (fails) when the pending reconciliation would delete more than maxDeleteFraction of live rows - the signature of a bulk transaction misclassified as a full refresh.
    forceReconcileSnapshotLsn provides a deliberate one-shot override. 
 */
-function volumeGuardQuery(
-    deletesTable,
-    versionTable,
-    latestTable,
-    primaryKeyField,
-    maxDeleteFraction,
-    forceReconcileSnapshotLsn
-) {
+function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDeleteFraction, forceReconcileSnapshotLsn}) {
   const overrideClause = forceReconcileSnapshotLsn
-    ? `\n  AND pending.snapshot_lsn != ${forceReconcileSnapshotLsn} /* one-shot override set in airbyteReconciliation */`
+    ? `
+  AND pending.snapshot_lsn != ${forceReconcileSnapshotLsn} /* one-shot override set in airbyteReconciliation; set, run, remove */`
     : '';
   return `WITH live AS (
   SELECT
     COUNT(*) AS live_row_count
   FROM
-    ${latestTable}
+    ${versionTable}
+  WHERE
+    valid_to IS NULL
 ),
 pending AS (
   SELECT
@@ -189,6 +177,24 @@ WHERE
   SAFE_DIVIDE(pending.pending_delete_count, live.live_row_count) > ${maxDeleteFraction}${overrideClause}`;
 }
 
+/* Step 4: apply. Folds inferred deletions into the version table exactly like observed CDC deletions: close the last live version. 
+   Idempotent: valid_to IS NULL excludes already-applied rows; a real CDC delete that beat us to the same PK in the same run also drops out. 
+   The ordering guard protects rows first seen during/after the snapshot. */
+function applyReconciliationQuery({ versionTable, deletesTable, primaryKeyField }) {
+  return `UPDATE ${versionTable} AS version
+SET
+  version.valid_to = log.deleted_at_assumed,
+  version.deleted_at = log.deleted_at_assumed,
+  version.is_current = FALSE,
+  version.is_deleted = TRUE
+FROM
+  ${deletesTable} AS log
+WHERE
+  version.${primaryKeyField} = log.${primaryKeyField}
+  AND version.valid_to IS NULL
+  AND version.valid_from < log.snapshot_started_at`;
+}
+
 /* Publish the functions above */
 module.exports = (params) => {
   if (!params.enableAirbyteSource || !params.airbyteReconciliation.enabled) return null;
@@ -200,44 +206,54 @@ module.exports = (params) => {
       type: "table",
       tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
       description: `[AIRBYTE] Full refresh snapshots of ${entitySchema.entityTableName} detected by LSN signature, used to reconcile deletions missed by CDC.`
-    }).query(ctx => fullRefreshDetectionQuery(
-      names.sourceTable,
-      ctx.resolve(names.latestTableName), // resolve, not ref: avoids dependency cycle
-      params.airbyteReconciliation.minLiveFraction,
-      params.airbyteReconciliation.minSnapshotAgeMinutes,
-      params.airbyteReconciliation.detectionWindowDays
-    ));
+    }).query(ctx => fullRefreshDetectionQuery({
+      sourceTable: names.sourceTable,
+      versionTable: ctx.ref(names.versionTableName), // ref: runs AFTER version exists - this is what makes new entities bootstrap safely
+      minLiveFraction: params.airbyteReconciliation.minLiveFraction,
+      minSnapshotAgeMinutes: params.airbyteReconciliation.minSnapshotAgeMinutes,
+      detectionWindowDays: params.airbyteReconciliation.detectionWindowDays
+    }));
 
     publish(names.reconciliationDeletesTableName, {
       type: "incremental",
-      protected: true, // survives full refreshes: this log is what stops version-table rebuilds resurrecting reconciled ghost rows
+      protected: true, // survives full refreshes: the log is the audit trail and what lets a version-table rebuild reproduce reconciled deletions
       uniqueKey: [names.primaryKey, "snapshot_lsn"],
       tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
-      description: `[AIRBYTE] Append-only log of ${entitySchema.entityTableName} entities inferred deleted because they were absent from an Airbyte full refresh. Consumed by the deletions logic in the version table; also the permanent audit trail of reconciled deletions. deleted_at_assumed is the snapshot extraction time, unlike CDC deletion timestamps which are source-database time.`
-    }).query(ctx => reconciliationDeletesQuery(
-      names.sourceTable,
-      ctx.ref(names.fullRefreshesTableName),
-      ctx.resolve(names.versionTableName),
-      names.primaryKey,
-      ctx.incremental() ? ctx.self() : null
-    ));
+      description: `[AIRBYTE] Append-only log of ${entitySchema.entityTableName} entities inferred deleted because they were absent from an Airbyte full refresh. deleted_at_assumed is snapshot extraction time, unlike CDC deletion timestamps which are source-database time.`
+    }).query(ctx => reconciliationDeletesQuery({
+      sourceTable: names.sourceTable,
+      detectionTable: ctx.ref(names.fullRefreshesTableName),
+      versionTable: ctx.ref(names.versionTableName),
+      primaryKeyField: names.primaryKey,
+      selfTable: ctx.incremental() ? ctx.self() : null
+    }));
 
-    return assert(names.volumeGuardAssertionName, {
+    assert(names.volumeGuardAssertionName, {
       tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
-      description: `[AIRBYTE] Blocks the ${entitySchema.entityTableName} version table if pending inferred deletions exceed airbyteReconciliation.maxDeleteFraction of live rows, which may indicate a bulk transaction misclassified as a full refresh.`
-    }).query(ctx => volumeGuardQuery(
-      ctx.ref(names.reconciliationDeletesTableName),
-      ctx.resolve(names.versionTableName),
-      ctx.resolve(names.latestTableName),
-      names.primaryKey,
-      params.airbyteReconciliation.maxDeleteFraction,
-      params.airbyteReconciliation.forceReconcileSnapshotLsn
-    ));
+      description: `[AIRBYTE] Blocks the reconciliation apply step for ${entitySchema.entityTableName} if pending inferred deletions exceed airbyteReconciliation.maxDeleteFraction of live rows, which may indicate a bulk transaction misclassified as a full refresh.`
+    }).query(ctx => volumeGuardQuery({
+      deletesTable: ctx.ref(names.reconciliationDeletesTableName),
+      versionTable: ctx.ref(names.versionTableName),
+      primaryKeyField: names.primaryKey,
+      maxDeleteFraction: params.airbyteReconciliation.maxDeleteFraction,
+      forceReconcileSnapshotLsn: params.airbyteReconciliation.forceReconcileSnapshotLsn
+    }));
+
+    return operate(names.applyOperationName, {
+      tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'reconciliation'],
+      dependencyTargets: [{ name: names.volumeGuardAssertionName }], // declarative circuit breaker
+      description: `[AIRBYTE] Applies inferred deletions from full refresh reconciliation to the ${entitySchema.entityTableName} version table by closing the last live version.`
+    }).queries(ctx => applyReconciliationQuery({
+      versionTable: ctx.ref(names.versionTableName),
+      deletesTable: ctx.ref(names.reconciliationDeletesTableName),
+      primaryKeyField: names.primaryKey
+    }));
   });
 };
 
-// Named properties for airbyte_entity_version.js and Jest:
+// Named properties for airbyte_entity_latest.js and Jest:
 module.exports.reconciliationNames = reconciliationNames;
 module.exports.fullRefreshDetectionQuery = fullRefreshDetectionQuery;
 module.exports.reconciliationDeletesQuery = reconciliationDeletesQuery;
 module.exports.volumeGuardQuery = volumeGuardQuery;
+module.exports.applyReconciliationQuery = applyReconciliationQuery;

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -139,7 +139,6 @@ function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDelet
   const overrideClause = forceReconcileSnapshotLsn
     ? `
   AND pending.snapshot_lsn != ${JSON.stringify(forceReconcileSnapshotLsn)} /* one-shot override set in airbyteReconciliation; set, run, remove */`
-
     : '';
   return `WITH live AS (
   SELECT
@@ -152,9 +151,7 @@ function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDelet
 pending AS (
   SELECT
     log.snapshot_lsn AS snapshot_lsn,
-
     COUNT(*) AS pending_delete_count
-
   FROM
     ${deletesTable} AS log
   INNER JOIN

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -135,7 +135,7 @@ WHERE
 function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDeleteFraction, forceReconcileSnapshotLsn}) {
   const overrideClause = forceReconcileSnapshotLsn
     ? `
-  AND pending.snapshot_lsn != ${forceReconcileSnapshotLsn} /* one-shot override set in airbyteReconciliation; set, run, remove */`
+  AND pending.snapshot_lsn != ${JSON.stringify(forceReconcileSnapshotLsn)} /* one-shot override set in airbyteReconciliation; set, run, remove */`
     : '';
   return `WITH live AS (
   SELECT
@@ -147,8 +147,8 @@ function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDelet
 ),
 pending AS (
   SELECT
-    COUNT(*) AS pending_delete_count,
-    ANY_VALUE(log.snapshot_lsn) AS snapshot_lsn
+    log.snapshot_lsn AS snapshot_lsn,
+    COUNT(*) AS pending_delete_count
   FROM
     ${deletesTable} AS log
   INNER JOIN
@@ -156,6 +156,8 @@ pending AS (
   ON
     version.${primaryKeyField} = log.${primaryKeyField}
     AND version.valid_to IS NULL
+  GROUP BY
+    log.snapshot_lsn
 )
 SELECT
   pending.snapshot_lsn,

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -106,6 +106,8 @@ snapshot_pks AS (
     latest_snapshot
   ON
     airbyte_source._ab_cdc_lsn = latest_snapshot.lsn
+    AND airbyte_source._airbyte_extracted_at >= latest_snapshot.snapshot_started_at 
+        AND latest_snapshot.snapshot_finished_at
 )
 SELECT
   version.${primaryKeyField} AS ${primaryKeyField},
@@ -135,7 +137,8 @@ WHERE
 function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDeleteFraction, forceReconcileSnapshotLsn}) {
   const overrideClause = forceReconcileSnapshotLsn
     ? `
-  AND pending.snapshot_lsn != ${JSON.stringify(forceReconcileSnapshotLsn)} /* one-shot override set in airbyteReconciliation; set, run, remove */`
+  AND pending.snapshot_lsn != ${JSON.stringify(forceReconcileSnapshotLsn)} /* one-shot override set in airbyteReconciliation; set, run, remove */`
+
     : '';
   return `WITH live AS (
   SELECT
@@ -147,8 +150,10 @@ function volumeGuardQuery({deletesTable, versionTable, primaryKeyField, maxDelet
 ),
 pending AS (
   SELECT
-    log.snapshot_lsn AS snapshot_lsn,
-    COUNT(*) AS pending_delete_count
+    log.snapshot_lsn AS snapshot_lsn,
+
+    COUNT(*) AS pending_delete_count
+
   FROM
     ${deletesTable} AS log
   INNER JOIN
@@ -156,8 +161,10 @@ pending AS (
   ON
     version.${primaryKeyField} = log.${primaryKeyField}
     AND version.valid_to IS NULL
-  GROUP BY
-    log.snapshot_lsn
+  GROUP BY
+
+    log.snapshot_lsn
+
 )
 SELECT
   pending.snapshot_lsn,

--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -25,6 +25,7 @@ function reconciliationNames(params, entitySchema) {
     primaryKey: entitySchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id',
     sourceTable: `\`${params.bqProjectName}.${params.airbyteConfig.datasetName}.${entitySchema.entityTableName}\``,
     versionTableName: `${entitySchema.entityTableName}_version_${params.eventSourceName}${suffix}`,
+    latestTableName: `${entitySchema.entityTableName}_latest_${params.eventSourceName}${suffix}`,
     fullRefreshesTableName: `${entitySchema.entityTableName}_airbyte_full_refreshes_${params.eventSourceName}`,
     reconciliationDeletesTableName: `${entitySchema.entityTableName}_airbyte_reconciliation_deletes_${params.eventSourceName}`,
     volumeGuardAssertionName: `${entitySchema.entityTableName}_airbyte_reconciliation_exceeds_safe_delete_volume_${params.eventSourceName}`,
@@ -149,6 +150,7 @@ WHERE
 function volumeGuardQuery(
     deletesTable,
     versionTable,
+    latestTable,
     primaryKeyField,
     maxDeleteFraction,
     forceReconcileSnapshotLsn
@@ -160,9 +162,7 @@ function volumeGuardQuery(
   SELECT
     COUNT(*) AS live_row_count
   FROM
-    ${versionTable}
-  WHERE
-    valid_to IS NULL
+    ${latestTable}
 ),
 pending AS (
   SELECT
@@ -202,7 +202,7 @@ module.exports = (params) => {
       description: `[AIRBYTE] Full refresh snapshots of ${entitySchema.entityTableName} detected by LSN signature, used to reconcile deletions missed by CDC.`
     }).query(ctx => fullRefreshDetectionQuery(
       names.sourceTable,
-      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      ctx.resolve(names.latestTableName), // resolve, not ref: avoids dependency cycle
       params.airbyteReconciliation.minLiveFraction,
       params.airbyteReconciliation.minSnapshotAgeMinutes,
       params.airbyteReconciliation.detectionWindowDays
@@ -217,7 +217,8 @@ module.exports = (params) => {
     }).query(ctx => reconciliationDeletesQuery(
       names.sourceTable,
       ctx.ref(names.fullRefreshesTableName),
-      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      ctx.resolve(names.versionTableName),
+      ctx.resolve(names.latestTableName),
       names.primaryKey,
       ctx.incremental() ? ctx.self() : null
     ));
@@ -227,7 +228,7 @@ module.exports = (params) => {
       description: `[AIRBYTE] Blocks the ${entitySchema.entityTableName} version table if pending inferred deletions exceed airbyteReconciliation.maxDeleteFraction of live rows, which may indicate a bulk transaction misclassified as a full refresh.`
     }).query(ctx => volumeGuardQuery(
       ctx.ref(names.reconciliationDeletesTableName),
-      ctx.resolve(names.versionTableName), // resolve, not ref: avoids dependency cycle
+      ctx.resolve(names.latestTableName),
       names.primaryKey,
       params.airbyteReconciliation.maxDeleteFraction,
       params.airbyteReconciliation.forceReconcileSnapshotLsn

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -195,9 +195,6 @@ function validateParams(params) {
             }
         });
 
-        if (params.airbyteReconciliation.enabled && !params.enableAirbyteSource) {
-            throw new Error("airbyteReconciliation.enabled requires enableAirbyteSource: true");
-        }
         if (!params.airbyteConfig) {
             throw new Error("airbyteConfig configuration block is required at the top level of the configuration passed to dfeAnalyticsDataform() when enableAirbyteSource is true.");
         }
@@ -206,8 +203,8 @@ function validateParams(params) {
         }
 
         if (params.hasTimestamps !== undefined && typeof params.hasTimestamps !== 'boolean') {
-    throw new Error(`hasTimestamps must be a boolean value (true or false), not "${params.hasTimestamps}".`);
-}
+            throw new Error(`hasTimestamps must be a boolean value (true or false), not "${params.hasTimestamps}".`);
+        }
 
         // Validate dataSchema has required fields for Airbyte
         params.dataSchema.forEach(entity => {
@@ -221,6 +218,10 @@ function validateParams(params) {
         throw new Error(`hasTimestamps for entity '${entity.entityTableName}' must be a boolean value (true or false), not "${entity.hasTimestamps}".`);
             }
         });
+    }
+
+    if (params.airbyteReconciliation.enabled && !params.enableAirbyteSource) {
+            throw new Error("airbyteReconciliation.enabled requires enableAirbyteSource: true");
     }
     return params;
 }

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -220,6 +220,15 @@ function validateParams(params) {
         });
     }
 
+    if (params.airbyteReconciliation !== undefined) {
+    if (typeof params.airbyteReconciliation !== 'object' || params.airbyteReconciliation === null) {
+        throw new Error(`airbyteReconciliation must be an object, not "${params.airbyteReconciliation}".`);
+    }
+    if (params.airbyteReconciliation.enabled !== undefined && typeof params.airbyteReconciliation.enabled !== 'boolean') {
+        throw new Error(`airbyteReconciliation.enabled must be a boolean, not "${params.airbyteReconciliation.enabled}".`);
+    }
+}
+
     return params;
 }
 

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -220,9 +220,6 @@ function validateParams(params) {
         });
     }
 
-    if (params.airbyteReconciliation.enabled && !params.enableAirbyteSource) {
-            throw new Error("airbyteReconciliation.enabled requires enableAirbyteSource: true");
-    }
     return params;
 }
 

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -29,7 +29,8 @@ const validTopLevelParameters = ['eventSourceName',
     'enableAirbyteSource',
     'airbyteConfig',
     'airbyteHeartbeat',
-    'hasTimestamps'
+    'hasTimestamps',
+    'airbyteReconciliation'
 ];
 const validDataSchemaTableParameters = ['entityTableName',
     'description',
@@ -194,6 +195,9 @@ function validateParams(params) {
             }
         });
 
+        if (params.airbyteReconciliation.enabled && !params.enableAirbyteSource) {
+            throw new Error("airbyteReconciliation.enabled requires enableAirbyteSource: true");
+        }
         if (!params.airbyteConfig) {
             throw new Error("airbyteConfig configuration block is required at the top level of the configuration passed to dfeAnalyticsDataform() when enableAirbyteSource is true.");
         }

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -221,13 +221,13 @@ function validateParams(params) {
     }
 
     if (params.airbyteReconciliation !== undefined) {
-    if (typeof params.airbyteReconciliation !== 'object' || params.airbyteReconciliation === null) {
-        throw new Error(`airbyteReconciliation must be an object, not "${params.airbyteReconciliation}".`);
+        if (typeof params.airbyteReconciliation !== 'object' || params.airbyteReconciliation === null) {
+            throw new Error(`airbyteReconciliation must be an object, not "${params.airbyteReconciliation}".`);
+        }
+        if (params.airbyteReconciliation.enabled !== undefined && typeof params.airbyteReconciliation.enabled !== 'boolean') {
+            throw new Error(`airbyteReconciliation.enabled must be a boolean, not "${params.airbyteReconciliation.enabled}".`);
+        }
     }
-    if (params.airbyteReconciliation.enabled !== undefined && typeof params.airbyteReconciliation.enabled !== 'boolean') {
-        throw new Error(`airbyteReconciliation.enabled must be a boolean, not "${params.airbyteReconciliation.enabled}".`);
-    }
-}
 
     return params;
 }

--- a/index.js
+++ b/index.js
@@ -115,6 +115,17 @@ module.exports = (params) => {
         ...params
     };
 
+    // Deep-merge this nested config so callers can override individual keys without losing defaults.
+    params.airbyteReconciliation = {
+        enabled: false,
+        minLiveFraction: 0.8,
+        maxDeleteFraction: 0.2,
+        minSnapshotAgeMinutes: 60,
+        detectionWindowDays: 7,
+        forceReconcileSnapshotLsn: null,
+        ...(params.airbyteReconciliation || {})
+    };
+
     // If disabled is true, stop right here, return no action definitions, and don't try to validate parameters
     if (params.disabled) {
         return true;

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ const airbyteSchemaAssertions = require("./includes/airbyte_schema_assertions");
 const airbyteEntityLatest = require("./includes/airbyte_entity_latest");
 const airbyteEntityVersion = require("./includes/airbyte_entity_version");
 const airbyteEntityDataNotFresh = require("./includes/airbyte_entity_data_not_fresh");
+const airbyteReconciliation = require("./includes/airbyte_reconciliation");
 
 module.exports = (params) => {
     // Set default values of parameters if parameters with the same name have not been passed to dfeAnalyticsDataform()
@@ -92,15 +93,24 @@ module.exports = (params) => {
             datasetName: null, // name of the BigQuery dataset that Airbyte streams data into
             tablePrefix: '', // prefix for Airbyte table names (e.g., '_airbyte_raw_')
             tableSuffix: '_airbyte', // Suffix for Airbyte output tables (to distinguish from dfe-analytics)
-            defaultPrimaryKeyField: 'id', // Default primary key field name (can be overridden per entity via tableSchema.primaryKey)
+            defaultPrimaryKeyField: 'id' // Default primary key field name (can be overridden per entity via tableSchema.primaryKey)
         },
 
         airbyteHeartbeat: {
                 freshnessHours: 12, // Number of hours to wait before triggering an assertion failure, if no new data has been received from Airbyte
                 datasetName: null, // name of the BigQuery dataset for heartbeat data.
                 tableName: 'airbyte_heartbeat', // name of the heartbeat table
-                disableFreshnessCheckDuringRange: false, // Boolean. If true, disables the heartbeat freshness check assertion during the date ranges specified in assertionDisableDuringDateRanges
-            },
+                disableFreshnessCheckDuringRange: false // Boolean. If true, disables the heartbeat freshness check assertion during the date ranges specified in assertionDisableDuringDateRanges
+        },
+
+        airbyteReconciliation: {
+                enabled: false,                       // opt-in, like enableAirbyteSource itself
+                minLiveFraction: 0.8,                 // snapshot mass threshold vs live rows
+                maxDeleteFraction: 0.2,               // circuit breaker trip level
+                minSnapshotAgeMinutes: 60,            // in-flight snapshot guard
+                detectionWindowDays: 7,               // raw-table scan window (partition pruning)
+                forceReconcileSnapshotLsn: null       // one-shot guard override; set, run, remove
+        },
 
         ...params
     };
@@ -177,6 +187,7 @@ module.exports = (params) => {
             airbyteEntityDataNotFresh: airbyteEntityDataNotFresh(params),
             airbyteGlobalDataFreshness: airbyteGlobalDataFreshness(params),
             airbyteSchemaAssertions: airbyteSchemaAssertions(params),
+            airbyteReconciliation: airbyteReconciliation(params)
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,6 @@ module.exports = (params) => {
         ...params
     };
 
-    // Deep-merge this nested config so callers can override individual keys without losing defaults.
     params.airbyteReconciliation = {
         enabled: false,
         minLiveFraction: 0.8,
@@ -123,7 +122,7 @@ module.exports = (params) => {
         minSnapshotAgeMinutes: 60,
         detectionWindowDays: 7,
         forceReconcileSnapshotLsn: null,
-        ...(params.airbyteReconciliation || {})
+        ...(params.airbyteReconciliation)
     };
 
     // If disabled is true, stop right here, return no action definitions, and don't try to validate parameters


### PR DESCRIPTION
## Context

Airbyte outages can miss CDC events, leaving BigQuery version tables out of sync, especially when deletion events are lost and rows remain live indefinitely.

This adds an opt-in reconciliation pipeline that detects completed Airbyte full-refresh snapshots by their LSN signature, infers which entities were absent from the snapshot, and applies those as soft deletions to the version table. A circuit breaker guards against bulk transactions being misclassified as full refreshes.

## What changed?

### New: `includes/airbyte_reconciliation.js`

New module, opt-in via `airbyteReconciliation.enabled: true`. When enabled, generates four new Dataform actions per entity in `dataSchema`:

| Action | Type | Purpose |
|---|---|---|
| `{entity}_airbyte_full_refreshes_{source}` | `table` | Detects completed full-refresh snapshots by LSN signature |
| `{entity}_airbyte_reconciliation_deletes_{source}` | `incremental`, `protected` | Append-only log of entities inferred deleted from the latest snapshot |
| `{entity}_airbyte_reconciliation_exceeds_safe_delete_volume_{source}` | assertion | Circuit breaker — blocks apply if inferred deletions exceed `maxDeleteFraction` |
| `{entity}_airbyte_reconciliation_apply_{source}` | `operate` | Applies inferred deletions to the version table |

Pipeline order per entity:

```
version → fullRefreshes → reconciliationDeletes → volumeGuard (assertion) → applyReconciliation (operate) → latest
```

**`fullRefreshes`** uses `ctx.ref(versionTableName)` so Dataform's dependency graph places version before it. This is what makes new entities bootstrap safely - version runs first, fullRefreshes can only run once version exists, no circular dependency.

**`reconciliationDeletes`** is `protected: true` - it survives a version table `--full-refresh`. This log is the audit trail and what prevents a rebuild from resurrecting reconciled ghost rows.

**`volumeGuard`** is a `dependencyTarget` on the `operate` step only, not on the version table.

**`applyReconciliation`** sets `valid_to`, `deleted_at`, `is_current = FALSE`, `is_deleted = TRUE` on the current live version row. Idempotent: the `valid_to IS NULL` filter means already-applied rows are skipped on retry.

### Changed: `includes/airbyte_entity_version.js`

- Fixed indentation

### Changed: `includes/airbyte_entity_latest.js`

- Added `airbyteReconciliation` require
- Added `applyOperationName` as an explicit dependency when `airbyteReconciliation.enabled: true`, so `latest` always runs after reconciliation has been applied and reads fully reconciled data

### Changed: `includes/parameter_functions.js`

- Added `airbyteReconciliation` to `validTopLevelParameters`
- Fixed indentation

### Changed: `index.js`

- Requires and wires up `airbyteReconciliation` module
- Adds `airbyteReconciliation` default config block with `enabled: false` (opt-in):

```javascript
airbyteReconciliation: {
    enabled: false,
    minLiveFraction: 0.8,        // snapshot must cover ≥80% of live rows to qualify for reconciliation operation
    maxDeleteFraction: 0.2,      // circuit breaker trips above 20% inferred deletions
    minSnapshotAgeMinutes: 60,   // in-flight snapshot guard
    detectionWindowDays: 7,      // raw table partition scan window
    forceReconcileSnapshotLsn: null  // one-shot circuit breaker override; set, run, remove
}
```

## Type of change

<!-- Select all that apply -->

* [ ] New package feature <!-- Adds new reusable Dataform functionality, such as a helper, include, assertion pattern, config option, or action generation utility. -->
* [x] Change to existing package feature <!-- Changes behaviour, parameters, defaults, generated SQL/actions, or assumptions of existing package functionality. -->
* [x] Bug fix <!-- Corrects package behaviour that was producing incorrect, incomplete, duplicated, unexpected, or inconsistent results. -->
* [ ] Refactor / performance <!-- Improves code structure, maintainability, compilation, runtime, cost, or query efficiency without intentionally changing behaviour. -->
* [ ] Documentation / metadata <!-- Adds or updates README content, usage examples, comments, metadata conventions, tags, or migration notes. -->
* [ ] Tests / validation <!-- Adds or updates tests, fixtures, assertions, validation logic, regression checks, or safeguards. -->
* [ ] Configuration / dependencies <!-- Updates Dataform config, package setup, workflow settings, npm dependencies, or shared package dependencies. -->
* [ ] Breaking change <!-- Changes package contracts in a way that may require consuming repos to update. -->
* [ ] Other: <!-- Use this for changes that do not fit the categories above. -->

## Downstream impact

<!-- Describe the expected impact on Dataform repos that consume this package. -->

* [x] No expected downstream changes.
* [x] Consuming repos may need to update package version.
* [ ] Consuming repos may need to update Dataform configuration.
* [ ] Consuming repos may need to update helper/include usage.
* [x] Consuming repos may see changes in compiled SQL or generated actions.
* [ ] Consuming repos may see changes in materialised outputs.
* [x] Migration guidance is included below.

### Migration guidance

**On first enable**, `{entity}_airbyte_full_refreshes_{source}` will be empty until a full refresh is detected within `detectionWindowDays`. No deletions will be applied during this window - verify the table is populating after enabling.

**If the circuit breaker trips** on a known legitimate large deletion, set `forceReconcileSnapshotLsn` to the relevant LSN, run once, then remove it.

## Notes for reviewers

## Reviewers Checklist

* [ ] The change belongs in the shared Dataform package rather than a consuming repo.
* [ ] The package interface is clear, reusable, and consistent with existing conventions.
* [ ] Generated SQL/actions, dependencies, tags, configs, assertions, or declarations are correct where relevant.
* [ ] Downstream impact has been considered and documented.
* [ ] Breaking changes are clearly flagged, with migration guidance where needed.
* [ ] Code is understandable and avoids unnecessary complexity or duplication.
* [ ] Relevant tests, fixtures, assertions, or regression checks are in place.
* [ ] Changes have been validated through Dataform compilation.
* [ ] README, usage examples, metadata, or comments are updated where relevant.
* [ ] Important assumptions, caveats, or non-obvious behaviours are documented.