### PR TITLE
Bugfix: Deduplicate inferred deletions per PK in reconciliation apply step

### DIFF
--- a/includes/airbyte_reconciliation.js
+++ b/includes/airbyte_reconciliation.js
@@ -187,8 +187,19 @@ SET
   version.deleted_at = log.deleted_at_assumed,
   version.is_current = FALSE,
   version.is_deleted = TRUE
-FROM
-  ${deletesTable} AS log
+FROM (
+  /* Deduplicate: one row per PK, using the earliest snapshot.
+     Without this, a PK that appears in multiple snapshots (multiple LSNs within detectionWindowDays) would match multiple source rows and BigQuery throws an error */
+  SELECT
+    ${primaryKeyField},
+    snapshot_started_at,
+    deleted_at_assumed
+  FROM ${deletesTable}
+  QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY ${primaryKeyField}
+    ORDER BY deleted_at_assumed ASC
+  ) = 1
+) AS log
 WHERE
   version.${primaryKeyField} = log.${primaryKeyField}
   AND version.valid_to IS NULL

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const version = "2.5.1";
+const version = "2.5.2";
 
 const parameterFunctions = require("./includes/parameter_functions");
 


### PR DESCRIPTION
## Context

`applyReconciliationQuery` closes the last live version of each inferred-deleted entity by joining the version table to the append-only deletes log on primary key.

Because the deletes log is unique by `(pk, snapshot_lsn)`, not just `pk`, a still-live PK can be logged under multiple snapshots.  When apply eventually runs, one live version row can match multiple delete-log rows, causing BigQuery to fail with:

`UPDATE/MERGE must match at most one source row for each target row`

The failure then compounds: since no rows are closed, later snapshots add more duplicate LSNs for the same PKs.

## What changed?

`includes/airbyte_reconciliation.js` - `applyReconciliationQuery`

The deletes log is now collapsed to one row per PK before the join, so the `UPDATE` always matches at most one source row per target row. The earliest snapshot per PK wins, which is the best estimate of when the row first went missing.

## Type of change

<!-- Select all that apply -->
* [x] Bug fix <!-- Corrects package behaviour that was producing incorrect, incomplete, duplicated, unexpected, or inconsistent results. -->

## Downstream impact

<!-- Describe the expected impact on Dataform repos that consume this package. -->
* [x] Consuming repos may need to update package version.
* [ ] Consuming repos may need to update Dataform configuration.

### Migration guidance

No manual cleanup required. Duplicate rows already accumulated in {entity}_airbyte_reconciliation_deletes_{source} are reduced at apply time by the dedup, so the next run succeeds without touching the log. 

## Notes for reviewers

Assumptions: The dedup selects the globally **earliest** logged snapshot per PK. For an entity that is deleted, re-created, then deleted again, the earliest log row predates the current version's valid_from; the valid_from < snapshot_started_at guard then filters it, and because the later (valid) row was already dropped by QUALIFY, the second deletion is skipped for that PK.
