### PR TITLE
Add legacy merge support for Airbyte entity version tables

### DIFF
--- a/definitions/bat_register_airbyte_test.js
+++ b/definitions/bat_register_airbyte_test.js
@@ -10,7 +10,7 @@ dfeAnalyticsDataform({
     bqDatasetName: "register_events_production",
     bqEventsTableName: "events",
     urlRegex: "register-trainee-teachers.service.gov.uk",
-    transformEntityEvents: false,
+    transformEntityEvents: true,
     compareChecksums: false,
     enableSessionTables: false,
     hiddenPolicyTagLocation: "projects/rugged-abacus-218110/locations/europe-west2/taxonomies/69524444121704657/policyTags/6523652585511281766",
@@ -26,6 +26,9 @@ dfeAnalyticsDataform({
         tableSuffix: "_airbyte",
         primaryKeyField: "id"
     },
+
+    enabledAirbyteLegacyMerge: true,
+    airbyteLegacyMergeCutoff: '2026-03-01',
 
     airbyteHeartbeat: {
         datasetName: "rtt_airbyte_production",
@@ -129,7 +132,7 @@ dfeAnalyticsDataform({
                 description: "Message describing the error in detail."
             }]
         },
-        {
+            {
             entityTableName: "bulk_update_trainee_uploads",
             materialisation: "view",
             description: "This table contains information about the bulk upload update for trainees",
@@ -746,7 +749,7 @@ dfeAnalyticsDataform({
             keys: [{
                     keyName: "additional_dttp_data",
                     dataType: "string",
-                    description: "Additional dttp data shown where applicable",
+                    description: "Additional dttp data shown were applicable",
                     hidden: true
                 }, {
                     keyName: "additional_ethnic_background",
@@ -940,7 +943,7 @@ dfeAnalyticsDataform({
                     keyName: "middle_names",
                     dataType: "string",
                     description: "Middle name(s) of the trainee",
-                    hidden: true
+                    hidden: true  
                 }, {
                     keyName: "training_partner_id",
                     pastKeyNames: ["lead_partner_id"],

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -215,7 +215,7 @@ ${injectLegacy ? `
     legacy_deletion_markers AS (
         SELECT * FROM (
             SELECT
-                CAST(${primaryKey} AS STRING) AS ${primaryKey},
+                CAST(id AS STRING) AS ${primaryKey},
                 ${legacyKeyProjection},
                 CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
                 valid_to AS cdc_updated_at,

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -16,8 +16,8 @@
    - other columns vary per entity (defined in dataSchema keys)
   
    Legacy merge:
-   Optionally seeds pre-cutoff version history from the legacy {eventSourceName}_entity_version
-   model (event-stream / dfe-analytics). Legacy versions are reshaped into the Airbyte source_data
+   Optionally seeds pre-cutoff version history from the legacy {entityTableName}_version_{eventSourceName}
+   model (from the event-stream / dfe-analytics pipeline via flattened_entity_version).
    column and injected BEFORE the window functions, so valid_to / is_current /
    version_number recompute across the cutoff seam. Applied on full-refresh only; on incremental
    runs the checkpoint is past the cutoff and legacy is never touched.

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -64,10 +64,9 @@ module.exports = (params) => {
         const versionCols = [
             primaryKey,
             ...keyList,
+            '_airbyte_extracted_at',
             'cdc_updated_at',
             'created_at',
-            '_airbyte_extracted_at',
-
             ...(hasTimestamps ? ['updated_at'] : []),
             'deleted_at',
             '_airbyte_raw_id'
@@ -177,6 +176,7 @@ WITH
     SELECT
       CAST(${primaryKey} AS STRING) AS ${primaryKey},
       ${airbyteKeyCastList}
+      _airbyte_extracted_at,
       TIMESTAMP(LEFT(_ab_cdc_updated_at, 26)) AS cdc_updated_at,
       ${hasTimestamps
         ? `TIMESTAMP(created_at) AS created_at, TIMESTAMP(updated_at) AS updated_at,`
@@ -200,13 +200,12 @@ ${injectLegacy ? `
     SELECT
         CAST(id AS STRING) AS ${primaryKey},
         ${legacyKeyProjection},
+        CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
         valid_from AS cdc_updated_at,
         ${hasTimestamps
             ? `created_at,
         COALESCE(updated_at, valid_from) AS updated_at,`
             : `CAST(NULL AS TIMESTAMP) AS created_at,`}
-        CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
-
         CAST(NULL AS TIMESTAMP) AS deleted_at,
         CAST(NULL AS STRING) AS _airbyte_raw_id
     FROM ${ctx.ref(legacyModel)}
@@ -218,12 +217,12 @@ ${injectLegacy ? `
             SELECT
                 CAST(${primaryKey} AS STRING) AS ${primaryKey},
                 ${legacyKeyProjection},
+                CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
                 valid_to AS cdc_updated_at,
                 ${hasTimestamps
                     ? `created_at,
             valid_to AS updated_at,`
                     : `CAST(NULL AS TIMESTAMP) AS created_at,`}
-                CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
                 valid_to AS deleted_at,
                 CAST(NULL AS STRING) AS _airbyte_raw_id
             FROM ${ctx.ref(legacyModel)}

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -16,8 +16,10 @@
    - other columns vary per entity (defined in dataSchema keys)
   
    Legacy merge:
-   Optionally seeds pre-cutoff version history from the legacy {entityTableName}_version_{eventSourceName}
-   model (from the event-stream / dfe-analytics pipeline via flattened_entity_version).
+   Optionally seeds pre-cutoff version history from the legacy {entityTableName}_version_{eventSourceName}
+
+   model (from the event-stream / dfe-analytics pipeline via flattened_entity_version).
+
    column and injected BEFORE the window functions, so valid_to / is_current /
    version_number recompute across the cutoff seam. Applied on full-refresh only; on incremental
    runs the checkpoint is past the cutoff and legacy is never touched.
@@ -63,6 +65,7 @@ module.exports = (params) => {
             ...keyList,
             'cdc_updated_at',
             'created_at',
+            '_airbyte_extracted_at',
             ...(hasTimestamps ? ['updated_at'] : []),
             'deleted_at',
             '_airbyte_raw_id'

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -205,7 +205,8 @@ ${injectLegacy ? `
             ? `created_at,
         COALESCE(updated_at, valid_from) AS updated_at,`
             : `CAST(NULL AS TIMESTAMP) AS created_at,`}
-        CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
+        CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
+
         CAST(NULL AS TIMESTAMP) AS deleted_at,
         CAST(NULL AS STRING) AS _airbyte_raw_id
     FROM ${ctx.ref(legacyModel)}
@@ -222,6 +223,7 @@ ${injectLegacy ? `
                     ? `created_at,
             valid_to AS updated_at,`
                     : `CAST(NULL AS TIMESTAMP) AS created_at,`}
+                CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
                 valid_to AS deleted_at,
                 CAST(NULL AS STRING) AS _airbyte_raw_id
             FROM ${ctx.ref(legacyModel)}

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -1,6 +1,6 @@
 /* Generates {entity}_version_{source}{suffix} tables from Airbyte Change Data Capture (CDC) data. 
 
-  Source table format (from Airbyte CDC, partitioned by _airbyte_extracted_at):
+   Source table format (from Airbyte CDC, partitioned by _airbyte_extracted_at):
    - One row per change event (insert/update/delete) captured by Change Data Capture
    - Each row contains the full entity state at the time of the change
    - Airbyte sync mode is incremental + append, so it only adds new entries when there are changes
@@ -14,7 +14,15 @@
        _ab_cdc_deleted_at     - Non-null only for deletion events
        _ab_cdc_lsn            - CDC log sequence number
    - other columns vary per entity (defined in dataSchema keys)
+  
+   Legacy merge:
+   Optionally seeds pre-cutoff version history from the legacy {eventSourceName}_entity_version
+   model (event-stream / dfe-analytics). Legacy versions are reshaped into the Airbyte source_data
+   column and injected BEFORE the window functions, so valid_to / is_current /
+   version_number recompute across the cutoff seam. Applied on full-refresh only; on incremental
+   runs the checkpoint is past the cutoff and legacy is never touched.
 */
+
 
 const data_functions = require("./data_functions");
 const parameterFunctions = require("./parameter_functions");
@@ -32,7 +40,65 @@ module.exports = (params) => {
 
         const fieldAssertionDependencies = params.airbyteEnableAssertions ?
             params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
+        
+        const legacyEnabled = params.enabledAirbyteLegacyMerge === true;
+        const legacyCutoff = params.airbyteLegacyMergeCutoff;
+        const legacyModel = entitySchema.entityTableName + "_version_" + params.eventSourceName;
+        if (legacyEnabled && !legacyCutoff) {
+            throw new Error(`enabledAirbyteLegacyMerge is true but AirbyteLegacyMergeCutoff was not provided (entity: ${entitySchema.entityTableName}).`);
+        }
 
+        /* Column that carries the version-ordering timestamp (matches the Airbyte model's). */
+        const orderCol = hasTimestamps ? 'updated_at' : 'cdc_updated_at';
+
+        /* Native entity columns == configured key names */
+        const outName = k => k.alias || k.keyName;
+        const mergeKeys = (entitySchema.keys || []).filter(k => outName(k) !== primaryKey);
+        const keyList = mergeKeys.map(outName);
+
+        /* Explicit, fixed column order used on BOTH sides of the UNION so alignment is positional-safe
+           regardless of the Airbyte table's physical column order. */
+        const versionCols = [
+            primaryKey,
+            ...keyList,
+            'cdc_updated_at',
+            'created_at',
+            ...(hasTimestamps ? ['updated_at'] : []),
+            'deleted_at',
+            '_airbyte_raw_id'
+        ];
+        const versionColsSql = versionCols.join(', ');
+
+        /* Cast raw columns to match the data type in dataSchema.*/
+        function airbyteKeyCast(key) {
+            if ((key.isArray || key.dataType === 'integer_array') && legacyEnabled) {
+                throw new Error(`airbyteKeyCast: array-typed key "${key.keyName}" (entity: ${entitySchema.entityTableName}) is not supported by the legacy merge yet.`);
+            }
+            if (key.historic) {
+                const bqType = { boolean: 'BOOL', integer: 'INT64', float: 'FLOAT64', timestamp: 'TIMESTAMP', date: 'DATE', json: 'JSON' }[key.dataType] || 'STRING';
+                return `CAST(NULL AS ${bqType})`;
+            }
+            const raw = '`' + key.keyName + '`';
+            const s = `CAST(${raw} AS STRING)`;
+            switch (key.dataType) {
+                case 'boolean':   return `SAFE_CAST(${s} AS BOOL)`;
+                case 'integer':   return `SAFE_CAST(${s} AS INT64)`;
+                case 'float':     return `SAFE_CAST(${s} AS FLOAT64)`;
+                case 'timestamp': return data_functions.stringToTimestamp(s);
+                case 'date':      return data_functions.stringToDate(s);
+                case 'json':      return `SAFE.PARSE_JSON(${s})`;
+                default:          return s; // string / undefined
+            }
+        }
+
+        const airbyteKeyCastList = mergeKeys.map(k =>
+            `${airbyteKeyCast(k)} AS \`${outName(k)}\`,`
+        ).join('\n        ');
+        
+        const legacyKeyProjection = mergeKeys.map(k =>
+            `\`${outName(k)}\``
+        ).join(',\n        ');
+        
         return publish(tableName, {
                 type: "incremental",
                 protected: false,
@@ -85,7 +151,18 @@ module.exports = (params) => {
             .preOps(ctx => `DECLARE extracted_at_checkpoint DEFAULT (
         ${ctx.when(ctx.incremental(), `SELECT MAX(_airbyte_extracted_at) FROM ${ctx.self()} WHERE valid_to IS NULL`, `SELECT TIMESTAMP("2026-01-01")`)}
         )`)
-            .query(ctx => `
+            .query(ctx => {
+
+            /* Legacy is seeded only on the full historical build. 
+               On incremental runs the checkpoint is past the cutoff, so legacy is neither scanned nor referenced. */
+            const injectLegacy = !ctx.incremental() && legacyEnabled;
+
+            /* What feeds the deletions / live_records split and the window functions. */
+            const versionInput = ctx.incremental()
+                ? `combined_with_current_versions`
+                : (injectLegacy ? `merged_full_history` : `source_data`);
+
+            return `
         
 WITH
   source_data AS (
@@ -94,16 +171,7 @@ WITH
      sync and a CDC event for the same entity both land in the same incremental run). */
     SELECT
       CAST(${primaryKey} AS STRING) AS ${primaryKey},
-      * EXCEPT (
-          ${primaryKey},
-          ${hasTimestamps ? 'created_at, updated_at,' : ''}
-          _airbyte_raw_id,
-          _airbyte_meta,
-          _airbyte_generation_id,
-          _ab_cdc_lsn,
-          _ab_cdc_updated_at,
-          _ab_cdc_deleted_at
-      ),
+      ${airbyteKeyCastList}
       TIMESTAMP(LEFT(_ab_cdc_updated_at, 26)) AS cdc_updated_at,
       ${hasTimestamps
         ? `TIMESTAMP(created_at) AS created_at, TIMESTAMP(updated_at) AS updated_at,`
@@ -121,6 +189,58 @@ WITH
       ORDER BY _airbyte_extracted_at DESC
     ) = 1
   ),
+
+${injectLegacy ? `
+    legacy_live AS (
+    SELECT
+        CAST(id AS STRING) AS ${primaryKey},
+        ${legacyKeyProjection},
+        valid_from AS cdc_updated_at,
+        ${hasTimestamps
+            ? `created_at,
+        COALESCE(updated_at, valid_from) AS updated_at,`
+            : `CAST(NULL AS TIMESTAMP) AS created_at,`}
+        CAST(NULL AS TIMESTAMP) AS deleted_at,
+        CAST(NULL AS STRING) AS _airbyte_raw_id
+    FROM ${ctx.ref(legacyModel)}
+    WHERE valid_from < TIMESTAMP("${legacyCutoff}")
+    ),
+
+    legacy_deletion_markers AS (
+        SELECT * FROM (
+            SELECT
+                CAST(${primaryKey} AS STRING) AS ${primaryKey},
+                ${legacyKeyProjection},
+                valid_to AS cdc_updated_at,
+                ${hasTimestamps
+                    ? `created_at,
+            valid_to AS updated_at,`
+                    : `CAST(NULL AS TIMESTAMP) AS created_at,`}
+                valid_to AS deleted_at,
+                CAST(NULL AS STRING) AS _airbyte_raw_id
+            FROM ${ctx.ref(legacyModel)}
+            WHERE valid_from < TIMESTAMP("${legacyCutoff}")
+            QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY valid_from DESC) = 1
+        )
+        WHERE deleted_at IS NOT NULL
+            AND deleted_at < TIMESTAMP("${legacyCutoff}")
+    ),
+
+    merged_full_history AS (
+        SELECT ${versionColsSql}
+        FROM (
+            SELECT ${versionColsSql}, 0 AS _merge_priority FROM source_data
+            UNION ALL
+            SELECT ${versionColsSql}, 1 AS _merge_priority FROM legacy_live
+            UNION ALL
+            SELECT ${versionColsSql}, 1 AS _merge_priority FROM legacy_deletion_markers
+        )
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY ${primaryKey}, ${orderCol}
+            ORDER BY _merge_priority
+        ) = 1
+    ),
+    ` : ``}
 
 ${ctx.incremental() ? `
   combined_with_current_versions AS (
@@ -151,7 +271,7 @@ ${ctx.incremental() ? `
     SELECT
     ${primaryKey},
     MAX(deleted_at) AS deleted_at
-    FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
+    FROM ${versionInput}
     WHERE deleted_at IS NOT NULL
     GROUP BY ${primaryKey}
     ),
@@ -191,7 +311,7 @@ ${ctx.incremental() ? `
     LEFT JOIN deletions USING (${primaryKey})
 
 
-`)
+`})
             .postOps(ctx => `
       ${data_functions.setKeyConstraints(ctx, dataform, {
         primaryKey: primaryKey + ", valid_from"

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -47,7 +47,8 @@ module.exports = (params) => {
         const legacyCutoff = params.airbyteLegacyMergeCutoff;
         const legacyModel = entitySchema.entityTableName + "_version_" + params.eventSourceName;
         if (legacyEnabled && !legacyCutoff) {
-            throw new Error(`enabledAirbyteLegacyMerge is true but airbyteLegacyMergeCutoff was not provided (entity: ${entitySchema.entityTableName}).`);
+            throw new Error(`enabledAirbyteLegacyMerge is true but airbyteLegacyMergeCutoff was not provided (entity: ${entitySchema.entityTableName}).`);
+
         }
 
         /* Column that carries the version-ordering timestamp (matches the Airbyte model's). */
@@ -204,6 +205,7 @@ ${injectLegacy ? `
             ? `created_at,
         COALESCE(updated_at, valid_from) AS updated_at,`
             : `CAST(NULL AS TIMESTAMP) AS created_at,`}
+        CAST(NULL AS TIMESTAMP) AS _airbyte_extracted_at,
         CAST(NULL AS TIMESTAMP) AS deleted_at,
         CAST(NULL AS STRING) AS _airbyte_raw_id
     FROM ${ctx.ref(legacyModel)}

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -285,7 +285,7 @@ ${ctx.incremental() ? `
 
   live_records AS (
     SELECT *
-    FROM ${ctx.incremental() ? `combined_with_current_versions` : `source_data`}
+    FROM ${versionInput}
     WHERE deleted_at IS NULL
   )
     SELECT

--- a/includes/airbyte_entity_version.js
+++ b/includes/airbyte_entity_version.js
@@ -47,7 +47,7 @@ module.exports = (params) => {
         const legacyCutoff = params.airbyteLegacyMergeCutoff;
         const legacyModel = entitySchema.entityTableName + "_version_" + params.eventSourceName;
         if (legacyEnabled && !legacyCutoff) {
-            throw new Error(`enabledAirbyteLegacyMerge is true but AirbyteLegacyMergeCutoff was not provided (entity: ${entitySchema.entityTableName}).`);
+            throw new Error(`enabledAirbyteLegacyMerge is true but airbyteLegacyMergeCutoff was not provided (entity: ${entitySchema.entityTableName}).`);
         }
 
         /* Column that carries the version-ordering timestamp (matches the Airbyte model's). */
@@ -65,7 +65,8 @@ module.exports = (params) => {
             ...keyList,
             'cdc_updated_at',
             'created_at',
-            '_airbyte_extracted_at',
+            '_airbyte_extracted_at',
+
             ...(hasTimestamps ? ['updated_at'] : []),
             'deleted_at',
             '_airbyte_raw_id'

--- a/includes/parameter_functions.js
+++ b/includes/parameter_functions.js
@@ -30,7 +30,9 @@ const validTopLevelParameters = ['eventSourceName',
     'airbyteConfig',
     'airbyteHeartbeat',
     'hasTimestamps',
-    'airbyteReconciliation'
+    'airbyteReconciliation',
+    'enabledAirbyteLegacyMerge',
+    'airbyteLegacyMergeCutoff'
 ];
 const validDataSchemaTableParameters = ['entityTableName',
     'description',

--- a/index.js
+++ b/index.js
@@ -97,8 +97,8 @@ module.exports = (params) => {
             
         },
 
-        enabledAirbyteLegacyMerge: true,
-        airbyteLegacyMergeCutoff: '2026-03-01',
+        enabledAirbyteLegacyMerge: false,
+        airbyteLegacyMergeCutoff: null,
 
         airbyteHeartbeat: {
                 freshnessHours: 12, // Number of hours to wait before triggering an assertion failure, if no new data has been received from Airbyte

--- a/index.js
+++ b/index.js
@@ -93,8 +93,12 @@ module.exports = (params) => {
             datasetName: null, // name of the BigQuery dataset that Airbyte streams data into
             tablePrefix: '', // prefix for Airbyte table names (e.g., '_airbyte_raw_')
             tableSuffix: '_airbyte', // Suffix for Airbyte output tables (to distinguish from dfe-analytics)
-            defaultPrimaryKeyField: 'id' // Default primary key field name (can be overridden per entity via tableSchema.primaryKey)
+            defaultPrimaryKeyField: 'id', // Default primary key field name (can be overridden per entity via tableSchema.primaryKey)
+            
         },
+
+        enabledAirbyteLegacyMerge: true,
+        airbyteLegacyMergeCutoff: '2026-03-01',
 
         airbyteHeartbeat: {
                 freshnessHours: 12, // Number of hours to wait before triggering an assertion failure, if no new data has been received from Airbyte


### PR DESCRIPTION
## Context

When services migrate from dfe-analytics (event-stream) to Airbyte CDC for entity versioning, there is a pre-cutoff period of version history that exists only in the legacy `{entity}_version_{source}` model. Without a way to seed this history into the new Airbyte-based version table, there is a gap in the `valid_from`/`valid_to` chain across the migration cutoff, and `is_current`/`version_number` calculations are incorrect for records that span that boundary.

This change adds an optional **legacy merge** feature to the `airbyte_entity_version` model, allowing consuming repos to inject pre-cutoff version history from the legacy event-stream model into the full-refresh build so that window functions recompute correctly across the cutoff seam.

## What changed?

- **`includes/airbyte_entity_version.js`**: Added `enabledAirbyteLegacyMerge` / `airbyteLegacyMergeCutoff` parameter support. On full-refresh builds, when the feature is enabled, three new CTEs are injected (`legacy_live`, `legacy_deletion_markers`, `merged_full_history`) that reshape legacy event-stream version rows into the Airbyte column schema and union them with `source_data` before the window functions run. On incremental runs, the legacy path is never touched. Replaced the `SELECT * EXCEPT (...)` pattern in `source_data` with an explicit, type-cast column list (`airbyteKeyCastList`) to guarantee positional safety in the union.
- **`includes/parameter_functions.js`**: Registered `enabledAirbyteLegacyMerge` and `airbyteLegacyMergeCutoff` as valid top-level parameters.
- **`index.js`**: Added `enabledAirbyteLegacyMerge` and `airbyteLegacyMergeCutoff` to the default parameter block.
- **`definitions/bat_register_airbyte_test.js`**: Updated the BAT Register test fixture to enable the legacy merge (`enabledAirbyteLegacyMerge: true`, `airbyteLegacyMergeCutoff: '2026-03-01'`) and switched `transformEntityEvents: true` to exercise the updated code path.

## Type of change

* [x] New package feature <!-- Adds new reusable Dataform functionality, such as a helper, include, assertion pattern, config option, or action generation utility. -->
* [x] Change to existing package feature <!-- Changes behaviour, parameters, defaults, generated SQL/actions, or assumptions of existing package functionality. -->

## Downstream impact

* [x] No expected downstream changes.
* [x] Consuming repos may need to update package version.
* [x] Consuming repos may need to update helper/include usage.
* [x] Consuming repos may see changes in compiled SQL or generated actions.

### Migration guidance

The legacy merge is **opt-in** and off by default. No changes are required in consuming repos unless they want to use it.

To enable, add the following to the top-level params block in your `dfeAnalyticsDataform({...})` call:

```js
enabledAirbyteLegacyMerge: true,
airbyteLegacyMergeCutoff: 'YYYY-MM-DD', // date on which your service cut over from dfe-analytics to Airbyte
```

Requirements:
- A `{entityTableName}_version_{eventSourceName}` model must exist and be referenceable (i.e. the legacy event-stream pipeline must still be present in the repo, at least as a declared/non-materialised table, for the full-refresh build to compile).
- Array-typed keys (`isArray: true` / `dataType: 'integer_array'`) are not yet supported by the legacy merge and will throw a compile-time error if the feature is enabled.
- The feature applies on **full-refresh only**. Incremental runs are unaffected.

## Notes for reviewers

- The `source_data` CTE has changed from `SELECT * EXCEPT (...)` to an explicit cast list. This is required for the `UNION ALL` with legacy rows to be column-safe, but it is also a behaviour change for all Airbyte entity version tables regardless of whether legacy merge is enabled — please review the cast logic in `airbyteKeyCast()` carefully, particularly for `timestamp`, `date`, and `json` types.
- `_merge_priority` is used to prefer Airbyte-sourced rows over legacy rows when both land on the same `(id, ordering_timestamp)` — Airbyte wins.
- The default values for `enabledAirbyteLegacyMerge` and `airbyteLegacyMergeCutoff` have been added to `index.js`. The switch default is false and the cutoff default is null to force consuming repos to set it explicitly.