### PR TITLE
Add field_updates tables for Airbyte entities

### DIFF
--- a/includes/airbyte_entity_field_updates.js
+++ b/includes/airbyte_entity_field_updates.js
@@ -15,6 +15,8 @@
    - An entity's first version produces no rows (LAG yields NULL previous_data, and the inner
      JOIN on UNNEST drops it), matching the legacy behaviour where creations only appear once a
      prior version exists to diff against.
+   - key_updated reports the *output* (aliased) field name, matching the column names in the
+     version and flattened tables, not the raw source column name.
 */
 
 const data_functions = require("./data_functions");
@@ -34,22 +36,31 @@ module.exports = (params) => {
         const fieldAssertionDependencies = params.airbyteEnableAssertions ?
             params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
 
+        /* The version table publishes each key under its alias when one is configured, falling
+           back to the raw source column name. Must match the version model's outName exactly. */
+        const outName = k => k.alias || k.keyName;
+
         /* Fields to diff between versions: configured keys, excluding
            - historic keys (no longer present as columns in the Airbyte source / version table)
            - the primary key itself (it can never change between versions of the same entity,
-             and for tables like sign_offs/disabilities it is only in keys to give it an alias) */
-        const trackedKeys = (tableSchema.keys || []).filter(k => !k.historic && k.keyName !== primaryKey);
+             and for tables like sign_offs/disabilities it is only in keys to give it an alias).
+             Compared on the output name, mirroring the version model's mergeKeys filter. */
+        const trackedKeys = (tableSchema.keys || []).filter(k => !k.historic && outName(k) !== primaryKey);
 
         /* Nothing to diff for this entity - don't publish a field updates relation at all. */
         if (trackedKeys.length === 0) return null;
 
-        /* Version table columns are the raw source column names (keyName), so reference those.
-           JSON-typed columns can't be CAST to STRING directly. */
+        /* Reference version table columns by their output (aliased) names - the raw keyName does
+           not exist as a column in the version table when an alias is configured.
+           JSON-typed columns can't be CAST to STRING directly.
+           The struct's key literal also uses the output name so that key_updated matches the
+           column names consumers see in the version and flattened tables. */
         const newDataStructSql = trackedKeys.map(k => {
+            const col = outName(k);
             const valueSql = k.dataType === 'json'
-                ? `TO_JSON_STRING(\`${k.keyName}\`)`
-                : `CAST(\`${k.keyName}\` AS STRING)`;
-            return `STRUCT('${k.keyName}' AS key, ${valueSql} AS value)`;
+                ? `TO_JSON_STRING(\`${col}\`)`
+                : `CAST(\`${col}\` AS STRING)`;
+            return `STRUCT('${col}' AS key, ${valueSql} AS value)`;
         }).join(',\n      ');
 
         return publish(tableName, {
@@ -85,7 +96,7 @@ module.exports = (params) => {
                     },
                     occurred_at: "Timestamp of the entity version that this field update was part of (valid_from in the version table).",
                     update_id: `UID for the collection of field updates that took place to this entity at this time. One-way hash of ${primaryKey} and occurred_at. Useful for COUNT DISTINCTs.`,
-                    key_updated: "The name of the field that was updated.",
+                    key_updated: "The name of the field that was updated, as it appears in the version table (i.e. the configured alias where one exists).",
                     new_value: {
                         description: "The value of this field after it was updated, cast to a string. Hidden because it may contain values of some fields which are configured to be hidden.",
                         bigqueryPolicyTags: params.hiddenPolicyTagLocation ? [params.hiddenPolicyTagLocation] : []

--- a/includes/airbyte_entity_field_updates.js
+++ b/includes/airbyte_entity_field_updates.js
@@ -1,0 +1,160 @@
+/* Generates {entity}_field_updates_{source}{suffix} tables from the Airbyte version tables.
+
+   One row for each time a field was updated on an entity, giving the field name, its previous
+   value and its new value. Derived from the {entity}_version_{source}{suffix} table by comparing
+   each version to the version immediately before it (LAG over valid_from).
+
+   Differences vs the legacy {eventSourceName}_entity_field_updates model:
+   - One output relation per entity (like the flattened field updates tables), keyed on the
+     entity's primary key column rather than a generic entity_id/entity_table_name pair.
+   - CDC data carries no web request context, so event_type, request_*, response_*, device/browser
+     and anonymised_user_agent_and_ip columns cannot be reproduced.
+   - Only fields configured in dataSchema keys are compared. updated_at is never in that list, and
+     historic keys are excluded (they no longer exist as columns in the Airbyte source), so the
+     legacy behaviour of ignoring updated_at churn is preserved automatically.
+   - An entity's first version produces no rows (LAG yields NULL previous_data, and the inner
+     JOIN on UNNEST drops it), matching the legacy behaviour where creations only appear once a
+     prior version exists to diff against.
+*/
+
+const data_functions = require("./data_functions");
+
+module.exports = (params) => {
+    if (!params.enableAirbyteSource) return null;
+
+    const suffix = params.airbyteConfig.tableSuffix || '_airbyte';
+
+    return params.dataSchema.map(tableSchema => {
+        const tableName = `${tableSchema.entityTableName}_field_updates_${params.eventSourceName}${suffix}`;
+        const versionTableName = `${tableSchema.entityTableName}_version_${params.eventSourceName}${suffix}`;
+        const primaryKey = tableSchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
+        const hasTimestamps = tableSchema.hasTimestamps;
+        const materialisation = tableSchema.materialisation || 'table';
+
+        const fieldAssertionDependencies = params.airbyteEnableAssertions ?
+            params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
+
+        /* Fields to diff between versions: configured keys, excluding
+           - historic keys (no longer present as columns in the Airbyte source / version table)
+           - the primary key itself (it can never change between versions of the same entity,
+             and for tables like sign_offs/disabilities it is only in keys to give it an alias) */
+        const trackedKeys = (tableSchema.keys || []).filter(k => !k.historic && k.keyName !== primaryKey);
+
+        /* Nothing to diff for this entity - don't publish a field updates relation at all. */
+        if (trackedKeys.length === 0) return null;
+
+        /* Version table columns are the raw source column names (keyName), so reference those.
+           JSON-typed columns can't be CAST to STRING directly. */
+        const newDataStructSql = trackedKeys.map(k => {
+            const valueSql = k.dataType === 'json'
+                ? `TO_JSON_STRING(\`${k.keyName}\`)`
+                : `CAST(\`${k.keyName}\` AS STRING)`;
+            return `STRUCT('${k.keyName}' AS key, ${valueSql} AS value)`;
+        }).join(',\n      ');
+
+        return publish(tableName, {
+                ...params.defaultConfig,
+                type: materialisation,
+                dependencies: fieldAssertionDependencies,
+                ...(materialisation == 'table' ? {
+                    assertions: {
+                        uniqueKey: [
+                            [primaryKey, "occurred_at", "key_updated"]
+                        ],
+                        nonNull: [primaryKey, "occurred_at", "key_updated"]
+                    }
+                } : {}),
+                bigquery: {
+                    ...(materialisation == 'table' ? {
+                        partitionBy: "DATE(occurred_at)",
+                        clusterBy: [primaryKey, "key_updated"]
+                    } : {}),
+                    labels: {
+                        eventsource: params.eventSourceName.toLowerCase(),
+                        sourcedataset: params.bqDatasetName.toLowerCase(),
+                        sourcetype: 'airbyte',
+                        entitytabletype: 'field_updates'
+                    }
+                },
+                tags: [params.eventSourceName.toLowerCase(), 'airbyte', 'field_updates'],
+                description: `[AIRBYTE] One row for each time a field was updated on a ${tableSchema.entityTableName} entity, giving the field name, its previous value and its new value. Derived from ${versionTableName} by comparing each version to the one immediately before it. An entity's first version, and changes to created_at/updated_at/${primaryKey}, are not included. ${tableSchema.description || ''}`,
+                columns: {
+                    [primaryKey]: {
+                        description: `Primary key of the ${tableSchema.entityTableName} entity that was updated.`,
+                        bigqueryPolicyTags: tableSchema.hidePrimaryKey && params.hiddenPolicyTagLocation ? [params.hiddenPolicyTagLocation] : []
+                    },
+                    occurred_at: "Timestamp of the entity version that this field update was part of (valid_from in the version table).",
+                    update_id: `UID for the collection of field updates that took place to this entity at this time. One-way hash of ${primaryKey} and occurred_at. Useful for COUNT DISTINCTs.`,
+                    key_updated: "The name of the field that was updated.",
+                    new_value: {
+                        description: "The value of this field after it was updated, cast to a string. Hidden because it may contain values of some fields which are configured to be hidden.",
+                        bigqueryPolicyTags: params.hiddenPolicyTagLocation ? [params.hiddenPolicyTagLocation] : []
+                    },
+                    previous_value: {
+                        description: "The value of this field before it was updated, cast to a string. Hidden because it may contain values of some fields which are configured to be hidden.",
+                        bigqueryPolicyTags: params.hiddenPolicyTagLocation ? [params.hiddenPolicyTagLocation] : []
+                    },
+                    previous_occurred_at: "Timestamp this entity was previously updated (valid_from of the previous version).",
+                    seconds_since_previous_update: "The number of seconds between occurred_at and previous_occurred_at.",
+                    ...(hasTimestamps ? {
+                        seconds_since_created: "The number of seconds between occurred_at and created_at."
+                    } : {})
+                }
+            })
+            .query(ctx => `
+WITH versions_with_new_data AS (
+  SELECT
+    ${primaryKey},
+    valid_from AS occurred_at,
+    ${hasTimestamps ? `created_at,` : ``}
+    [${newDataStructSql}] AS new_data
+  FROM
+    ${ctx.ref(versionTableName)}
+),
+
+versions_with_field_arrays AS (
+  SELECT
+    ${primaryKey},
+    occurred_at,
+    ${hasTimestamps ? `created_at,` : ``}
+    new_data,
+    LAG(new_data) OVER versions_of_this_entity AS previous_data,
+    LAG(occurred_at) OVER versions_of_this_entity AS previous_occurred_at
+  FROM
+    versions_with_new_data
+  WINDOW versions_of_this_entity AS (
+    PARTITION BY ${primaryKey}
+    ORDER BY occurred_at ASC
+  )
+)
+
+SELECT
+  versions_with_field_arrays.${primaryKey},
+  occurred_at,
+  FARM_FINGERPRINT(${primaryKey} || CAST(occurred_at AS STRING)) AS update_id,
+  new_data_combined.key AS key_updated,
+  new_data_combined.value AS new_value,
+  previous_data_combined.value AS previous_value,
+  previous_occurred_at,
+  TIMESTAMP_DIFF(occurred_at, previous_occurred_at, SECOND) AS seconds_since_previous_update
+  ${hasTimestamps ? `, TIMESTAMP_DIFF(occurred_at, created_at, SECOND) AS seconds_since_created` : ``}
+FROM
+  versions_with_field_arrays
+  CROSS JOIN UNNEST(new_data) AS new_data_combined
+  JOIN UNNEST(previous_data) AS previous_data_combined ON new_data_combined.key = previous_data_combined.key
+WHERE
+  IFNULL(new_data_combined.value, "null") != IFNULL(previous_data_combined.value, "null")
+`)
+            .postOps(ctx => materialisation == 'table'
+                /* Key constraints can only be set on tables - ALTER TABLE ... ADD PRIMARY KEY /
+                   ADD CONSTRAINT fails with "ALTER TABLE only supports altering constraints for
+                   tables" when the entity is materialised as a view. */
+                ? `${data_functions.setKeyConstraints(ctx, dataform, {
+                    primaryKey: `${primaryKey}, occurred_at, key_updated`,
+                    foreignKeys: [
+                        {keyInThisTable: `${primaryKey}, occurred_at`, foreignTable: versionTableName, keyInForeignTable: `${primaryKey}, valid_from`}
+                    ]
+                })}`
+                : ``)
+    }).filter(Boolean);
+};

--- a/includes/airbyte_entity_field_updates.js
+++ b/includes/airbyte_entity_field_updates.js
@@ -29,7 +29,7 @@ module.exports = (params) => {
     return params.dataSchema.map(tableSchema => {
         const tableName = `${tableSchema.entityTableName}_field_updates_${params.eventSourceName}${suffix}`;
         const versionTableName = `${tableSchema.entityTableName}_version_${params.eventSourceName}${suffix}`;
-        const primaryKey = tableSchema.primaryKey || params.airbyteConfig.primaryKeyField || 'id';
+        const primaryKey = tableSchema.primaryKey || params.airbyteConfig.defaultPrimaryKeyField || 'id';
         const hasTimestamps = tableSchema.hasTimestamps;
         const materialisation = tableSchema.materialisation || 'table';
 

--- a/includes/airbyte_entity_field_updates.js
+++ b/includes/airbyte_entity_field_updates.js
@@ -1,8 +1,7 @@
 /* Generates {entity}_field_updates_{source}{suffix} tables from the Airbyte version tables.
-
    One row for each time a field was updated on an entity, giving the field name, its previous
    value and its new value. Derived from the {entity}_version_{source}{suffix} table by comparing
-   each version to the version immediately before it (LAG over valid_from).
+   each version to the version immediately before it (LAG over version_number).
 
    Differences vs the legacy {eventSourceName}_entity_field_updates model:
    - One output relation per entity (like the flattened field updates tables), keyed on the
@@ -20,6 +19,7 @@
 */
 
 const data_functions = require("./data_functions");
+const airbyteReconciliation = require("./airbyte_reconciliation");
 
 module.exports = (params) => {
     if (!params.enableAirbyteSource) return null;
@@ -32,9 +32,6 @@ module.exports = (params) => {
         const primaryKey = tableSchema.primaryKey || params.airbyteConfig.defaultPrimaryKeyField || 'id';
         const hasTimestamps = tableSchema.hasTimestamps;
         const materialisation = tableSchema.materialisation || 'table';
-
-        const fieldAssertionDependencies = params.airbyteEnableAssertions ?
-            params.dataSchema.map(schema => schema.entityTableName + "_airbyte_fields_not_in_schema_" + params.eventSourceName) : [];
 
         /* The version table publishes each key under its alias when one is configured, falling
            back to the raw source column name. Must match the version model's outName exactly. */
@@ -66,7 +63,14 @@ module.exports = (params) => {
         return publish(tableName, {
                 ...params.defaultConfig,
                 type: materialisation,
-                dependencies: fieldAssertionDependencies,
+                /* The schema assertions are already upstream of this table via the version table
+                   (ctx.ref below), so they don't need repeating here. The reconciliation apply
+                   operation is not in the ref graph, so it does. */
+                dependencies: [
+                    ...(params.airbyteReconciliation.enabled
+                        ? [airbyteReconciliation.reconciliationNames(params, tableSchema).applyOperationName]
+                        : [])
+                ],
                 ...(materialisation == 'table' ? {
                     assertions: {
                         uniqueKey: [
@@ -116,13 +120,13 @@ module.exports = (params) => {
 WITH versions_with_new_data AS (
   SELECT
     ${primaryKey},
+    version_number,
     valid_from AS occurred_at,
     ${hasTimestamps ? `created_at,` : ``}
     [${newDataStructSql}] AS new_data
   FROM
     ${ctx.ref(versionTableName)}
 ),
-
 versions_with_field_arrays AS (
   SELECT
     ${primaryKey},
@@ -135,10 +139,9 @@ versions_with_field_arrays AS (
     versions_with_new_data
   WINDOW versions_of_this_entity AS (
     PARTITION BY ${primaryKey}
-    ORDER BY occurred_at ASC
+    ORDER BY version_number ASC
   )
 )
-
 SELECT
   versions_with_field_arrays.${primaryKey},
   occurred_at,

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const airbyteEntityLatest = require("./includes/airbyte_entity_latest");
 const airbyteEntityVersion = require("./includes/airbyte_entity_version");
 const airbyteEntityDataNotFresh = require("./includes/airbyte_entity_data_not_fresh");
 const airbyteReconciliation = require("./includes/airbyte_reconciliation");
+const airbyteEntityFieldUpdates = require("./includes/airbyte_entity_field_updates");
 
 module.exports = (params) => {
     // Set default values of parameters if parameters with the same name have not been passed to dfeAnalyticsDataform()
@@ -197,7 +198,8 @@ module.exports = (params) => {
             airbyteEntityDataNotFresh: airbyteEntityDataNotFresh(params),
             airbyteGlobalDataFreshness: airbyteGlobalDataFreshness(params),
             airbyteSchemaAssertions: airbyteSchemaAssertions(params),
-            airbyteReconciliation: airbyteReconciliation(params)
+            airbyteReconciliation: airbyteReconciliation(params),
+            airbyteEntityFieldUpdates: airbyteEntityFieldUpdates(params)
         });
     }
 


### PR DESCRIPTION
Services that have migrated to the Airbyte CDC source currently get _latest and _version tables per entity, but have no equivalent of the legacy {eventSourceName}_entity_field_updates / flattened field updates models. Consumers that depend on field-level change history (one row per field change, with previous and new values) therefore have nothing to point at on the Airbyte side.

This change adds an airbyte_entity_field_updates model that derives field-level change history directly from the Airbyte version tables, by comparing each version of an entity to the version immediately before it.

**What changed?**

includes/airbyte_entity_field_updates.js (new): Generates one {entity}_field_updates_{eventSourceName}{suffix} relation per entity in dataSchema. Each version row is diffed against its predecessor (LAG over valid_from, partitioned by the primary key), producing one row per changed field with key_updated, previous_value, new_value, occurred_at, previous_occurred_at, update_id, seconds_since_previous_update, and (for hasTimestamps entities) seconds_since_created. Tables are partitioned by DATE(occurred_at), clustered by the primary key and key_updated, carry uniqueness/non-null assertions, and set primary/foreign key constraints back to the version table. new_value/previous_value are policy-tagged as hidden, and hidePrimaryKey is respected.
index.js: Registered airbyteEntityFieldUpdates(params) in the enableAirbyteSource output block.

Behavioural notes relative to the legacy event-stream field updates models:


One output relation per entity, keyed on the entity's primary key column, rather than a single generic table keyed on entity_id/entity_table_name.
CDC data carries no web request context, so event_type, request_*, response_*, device/browser and anonymised_user_agent_and_ip columns cannot be reproduced.
Only fields configured in dataSchema keys are compared; historic keys and the primary key are excluded, so updated_at churn is ignored automatically.
An entity's first version produces no rows, matching legacy behaviour where creations only appear once a prior version exists to diff against.
key_updated reports the output (aliased) field name, matching the column names in the version and flattened tables.
Entities with no diffable keys (only historic keys and/or the primary key) publish no field updates relation at all.
materialisation: 'view' is respected; assertions, partitioning and key constraints are only applied when materialised as a table.

**Type of change**

- [x]  New package feature
- [ ]  Change to existing package feature
- [ ]  Bug fix
- [ ]  Documentation-only change

**Downstream impact**

- [ ]  No expected downstream changes
- [x]  Consuming repos may need to update package version
- [ ]  Consuming repos may need to update helper/include usage
- [x]  Consuming repos may see changes in compiled SQL or generated actions

Repos with enableAirbyteSource: true will automatically gain the new field updates actions (tables, assertions and constraints) on their next package version bump — there is no separate opt-in switch.

**Notes for reviewers**

The diff compares string-cast values (TO_JSON_STRING for json-typed keys, CAST(... AS STRING) otherwise) with NULLs coalesced to the literal "null", so NULL → non-NULL and non-NULL → NULL transitions are captured, but a genuine NULL and the string "null" are indistinguishable.
The inner JOIN UNNEST(previous_data) is what drops first versions (previous_data is NULL) — creations intentionally emit no rows.
Please check the outName handling: the struct key literal, the diffed column references, and the exclusion of the primary key all operate on the aliased output name, and must stay in lockstep with the version model's mergeKeys filter.
postOps key constraints are skipped for view materialisations because ALTER TABLE ... ADD CONSTRAINT fails on views.